### PR TITLE
Expose abs

### DIFF
--- a/crates/float/src/lib.rs
+++ b/crates/float/src/lib.rs
@@ -446,7 +446,7 @@ mod tests {
 
     proptest! {
         #[test]
-        fn test_abs_no_minus_sign(float in arb_float()) {
+        fn test_abs_no_minus_sign(float in reasonable_float()) {
             let abs = float.abs().unwrap();
             let formatted = abs.format().unwrap();
             prop_assert!(!formatted.starts_with("-"));

--- a/crates/float/src/lib.rs
+++ b/crates/float/src/lib.rs
@@ -231,11 +231,11 @@ impl Float {
         })
     }
 
-    pub fn abs(&mut self, float: Float) -> Result<Float, CalculatorError> {
-        let Float(a) = float;
+    pub fn abs(self) -> Result<Float, FloatError> {
+        let Float(a) = self;
         let calldata = DecimalFloat::absCall { a }.abi_encode();
 
-        self.execute_call(Bytes::from(calldata), |output| {
+        execute_call(Bytes::from(calldata), |output| {
             let decoded = DecimalFloat::absCall::abi_decode_returns(output.as_ref())?;
             Ok(Float(decoded))
         })
@@ -428,41 +428,35 @@ mod tests {
 
     #[test]
     fn test_abs() {
-        let mut calculator = Calculator::new().unwrap();
-
-        let float = calculator.parse("-3613.1324123".to_string()).unwrap();
-        let abs = calculator.abs(float).unwrap();
-        let formatted = calculator.format(abs).unwrap();
+        let float = Float::parse("-3613.1324123".to_string()).unwrap();
+        let abs = float.abs().unwrap();
+        let formatted = abs.format().unwrap();
         assert_eq!(formatted, "3613.1324123");
 
-        let float = calculator.parse("3613.1324123".to_string()).unwrap();
-        let abs = calculator.abs(float).unwrap();
-        let formatted = calculator.format(abs).unwrap();
+        let float = Float::parse("3613.1324123".to_string()).unwrap();
+        let abs = float.abs().unwrap();
+        let formatted = abs.format().unwrap();
         assert_eq!(formatted, "3613.1324123");
 
-        let float = calculator.parse("0".to_string()).unwrap();
-        let abs = calculator.abs(float).unwrap();
-        let formatted = calculator.format(abs).unwrap();
+        let float = Float::parse("0".to_string()).unwrap();
+        let abs = float.abs().unwrap();
+        let formatted = abs.format().unwrap();
         assert_eq!(formatted, "0");
     }
 
     proptest! {
         #[test]
-        fn test_abs_no_minus_sign(float in valid_float()) {
-            let mut calculator = Calculator::new().unwrap();
-
-            let abs = calculator.abs(float).unwrap();
-            let formatted = calculator.format(abs).unwrap();
+        fn test_abs_no_minus_sign(float in arb_float()) {
+            let abs = float.abs().unwrap();
+            let formatted = abs.format().unwrap();
             prop_assert!(!formatted.starts_with("-"));
         }
 
         #[test]
-        fn test_abs_abs(float in valid_float()) {
-            let mut calculator = Calculator::new().unwrap();
-
-            let abs = calculator.abs(float).unwrap();
-            let abs_abs = calculator.abs(abs).unwrap();
-            prop_assert!(calculator.eq(abs, abs_abs).unwrap());
+        fn test_abs_abs(float in arb_float()) {
+            let abs = float.abs().unwrap();
+            let abs_abs = abs.abs().unwrap();
+            prop_assert!(abs.eq(abs_abs).unwrap());
         }
     }
 }


### PR DESCRIPTION
## Motivation

We need to use Solidity Float code in Rust

## Solution

Expose `abs` method

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an absolute value calculation for floats, allowing users to obtain the non-negative value of any float.

- **Tests**
  - Added tests to ensure correct behavior of the absolute value calculation, including checks for negative, positive, and zero values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->