### PR TITLE
neg float parse bug

### DIFF
--- a/src/lib/parse/LibParseDecimalFloat.sol
+++ b/src/lib/parse/LibParseDecimalFloat.sol
@@ -36,14 +36,14 @@ library LibParseDecimalFloat {
         unchecked {
             cursor = start;
             cursor = LibParseChar.skipMask(cursor, end, CMASK_NEGATIVE_SIGN);
+            bool isNegative = cursor != start;
             {
                 uint256 intStart = cursor;
                 cursor = LibParseChar.skipMask(cursor, end, CMASK_NUMERIC_0_9);
                 if (cursor == intStart) {
                     return (ParseEmptyDecimalString.selector, cursor, 0, 0);
                 }
-            }
-            {
+
                 (bytes4 signedCoefficientErrorSelector, int256 signedCoefficientTmp) =
                     LibParseDecimal.unsafeDecimalStringToSignedInt(start, cursor);
                 if (signedCoefficientErrorSelector != 0) {
@@ -80,7 +80,7 @@ library LibParseDecimalFloat {
                 if (fracValue < 0) {
                     return (MalformedDecimalPoint.selector, cursor, 0, 0);
                 }
-                if (signedCoefficient < 0) {
+                if (isNegative) {
                     fracValue = -fracValue;
                 }
 

--- a/test/src/lib/parse/LibParseDecimalFloat.t.sol
+++ b/test/src/lib/parse/LibParseDecimalFloat.t.sol
@@ -378,8 +378,4 @@ contract LibParseDecimalFloatTest is Test {
             69
         );
     }
-
-    function testParseLiteralDecimalFloatPrecisionRevert2() external pure {
-        checkParseDecimalFloatFail("1341234234625468391.1341234234625468391", ParseDecimalPrecisionLoss.selector, 158);
-    }
 }

--- a/test/src/lib/parse/LibParseDecimalFloat.t.sol
+++ b/test/src/lib/parse/LibParseDecimalFloat.t.sol
@@ -262,9 +262,10 @@ contract LibParseDecimalFloatTest is Test {
         checkParseDecimalFloat("1.1e1", 11, 0, 5);
         checkParseDecimalFloat("1.1e-1", 11, -2, 6);
 
-        // Some negatives.
+        // // Some negatives.
         checkParseDecimalFloat("-1.1e-1", -11, -2, 7);
         checkParseDecimalFloat("-10.01e-1", -1001, -3, 9);
+        checkParseDecimalFloat("-0.1", -1, -1, 4);
     }
 
     /// Test some unrelated data after the decimal.
@@ -376,5 +377,9 @@ contract LibParseDecimalFloatTest is Test {
             ParseDecimalPrecisionLoss.selector,
             69
         );
+    }
+
+    function testParseLiteralDecimalFloatPrecisionRevert2() external pure {
+        checkParseDecimalFloatFail("1341234234625468391.1341234234625468391", ParseDecimalPrecisionLoss.selector, 158);
     }
 }

--- a/test/src/lib/parse/LibParseDecimalFloat.t.sol
+++ b/test/src/lib/parse/LibParseDecimalFloat.t.sol
@@ -262,7 +262,7 @@ contract LibParseDecimalFloatTest is Test {
         checkParseDecimalFloat("1.1e1", 11, 0, 5);
         checkParseDecimalFloat("1.1e-1", 11, -2, 6);
 
-        // // Some negatives.
+        // Some negatives.
         checkParseDecimalFloat("-1.1e-1", -11, -2, 7);
         checkParseDecimalFloat("-10.01e-1", -1001, -3, 9);
         checkParseDecimalFloat("-0.1", -1, -1, 4);


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of negative decimal float parsing for more accurate results.
- **Tests**
	- Added test cases for parsing negative decimal floats and for handling precision loss errors with large numbers.
	- Added a test case to verify correct parsing of the string "-0.1".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->