### PR TITLE
Expose mul & div

### DIFF
--- a/crates/float/src/lib.rs
+++ b/crates/float/src/lib.rs
@@ -296,6 +296,7 @@ impl Div for Float {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::str::FromStr;
     use proptest::prelude::*;
 
     prop_compose! {
@@ -374,6 +375,39 @@ mod tests {
             let parsed = Float::parse(formatted.clone()).unwrap();
             prop_assert_eq!(float.0, parsed.0);
         }
+    }
+
+    #[test]
+    fn test_add_exponent_overflow_error() {
+        let max_coeff_str = "13479973333575319897333507543509815336818572211270286240551805124607";
+        let large_coeff_i224 = I224::from_str(max_coeff_str).unwrap();
+        let exponent_max = i32::MAX;
+
+        let a = Float::pack_lossless(large_coeff_i224, exponent_max).unwrap();
+
+        let err = (a + a).unwrap_err();
+
+        assert!(matches!(
+            err,
+            FloatError::DecimalFloat(DecimalFloatErrors::ExponentOverflow(_))
+        ));
+    }
+
+    #[test]
+    fn test_sub_exponent_overflow_error() {
+        let max_coeff_str = "13479973333575319897333507543509815336818572211270286240551805124607";
+        let large_coeff_i224 = I224::from_str(max_coeff_str).unwrap();
+        let exponent_max = i32::MAX;
+
+        let a = Float::pack_lossless(large_coeff_i224, exponent_max).unwrap();
+        let b = Float::pack_lossless(-large_coeff_i224, exponent_max).unwrap();
+
+        let err = (b - a).unwrap_err();
+
+        assert!(matches!(
+            err,
+            FloatError::DecimalFloat(DecimalFloatErrors::ExponentOverflow(_))
+        ));
     }
 
     proptest! {

--- a/crates/float/src/lib.rs
+++ b/crates/float/src/lib.rs
@@ -519,12 +519,43 @@ mod tests {
         let one = Float::parse("1".to_string()).unwrap();
         let zero = Float::parse("0".to_string()).unwrap();
         let err = (one / zero).unwrap_err();
-        // Division by zero should revert or return a DecimalFloat error/selector.
-        match err {
-            FloatError::DecimalFloat(_)
-            | FloatError::DecimalFloatSelector(_)
-            | FloatError::Revert(_) => {}
-            _ => panic!("Unexpected error type: {err:?}"),
-        }
+
+        assert!(matches!(err, FloatError::Revert(_)));
+    }
+
+    #[test]
+    fn test_mul_exponent_overflow_error() {
+        let near_max_exp = Float::parse("1e2147483646".to_string()).unwrap();
+        let one_e_two = Float::parse("1e2".to_string()).unwrap();
+
+        let err = (near_max_exp * one_e_two).unwrap_err();
+        assert!(matches!(
+            err,
+            FloatError::DecimalFloat(DecimalFloatErrors::ExponentOverflow(_))
+        ));
+    }
+
+    #[test]
+    fn test_div_exponent_overflow_error() {
+        let near_max_exp = Float::parse("1e2147483646".to_string()).unwrap();
+        let one_e_neg_hundred = Float::parse("1e-100".to_string()).unwrap();
+
+        let err = (near_max_exp / one_e_neg_hundred).unwrap_err();
+        assert!(matches!(
+            err,
+            FloatError::DecimalFloat(DecimalFloatErrors::ExponentOverflow(_))
+        ));
+    }
+
+    #[test]
+    fn test_mul_exponent_underflow_error() {
+        let near_min_exp = Float::parse("1e-2147483646".to_string()).unwrap();
+        let one_e_neg_three = Float::parse("1e-3".to_string()).unwrap();
+
+        let err = (near_min_exp * one_e_neg_three).unwrap_err();
+        assert!(matches!(
+            err,
+            FloatError::DecimalFloat(DecimalFloatErrors::ExponentOverflow(_))
+        ));
     }
 }


### PR DESCRIPTION
## Motivation

We need to use Solidity Float code in Rust

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Expose `mul` and `div` methods

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for multiplication and division operations with the Float type.
- **Bug Fixes**
	- Improved error handling for parsing errors, exponent overflows, and division by zero.
- **Tests**
	- Expanded test coverage for multiplication, division, and various edge cases, including overflow, underflow, and error scenarios.
- **Documentation**
	- Updated documentation to clarify decimal handling in formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->