### PR TITLE
fix bindings

### DIFF
--- a/crates/float/src/js_api.rs
+++ b/crates/float/src/js_api.rs
@@ -138,8 +138,9 @@ impl Float {
     /// assert(float.format() === "123.45");
     /// ```
     #[wasm_export(js_name = "fromFixedDecimal", preserve_js_class)]
-    pub fn from_fixed_decimal_js(value: String, decimals: u8) -> Result<Float, FloatError> {
-        let val = U256::from_str(&value)?;
+    pub fn from_fixed_decimal_js(value: BigInt, decimals: u8) -> Result<Float, FloatError> {
+        let value_str: String = value.to_string(10)?.into();
+        let val = U256::from_str(&value_str)?;
         Self::from_fixed_decimal(val, decimals)
     }
 
@@ -164,10 +165,15 @@ impl Float {
     /// }
     /// assert(result.value === "12345");
     /// ```
-    #[wasm_export(js_name = "toFixedDecimal")]
-    pub fn to_fixed_decimal_js(&self, decimals: u8) -> Result<String, FloatError> {
+    #[wasm_export(
+        js_name = "toFixedDecimal",
+        preserve_js_class,
+        unchecked_return_type = "bigint"
+    )]
+    pub fn to_fixed_decimal_js(&self, decimals: u8) -> Result<BigInt, FloatError> {
         let fixed = self.to_fixed_decimal(decimals)?;
-        Ok(fixed.to_string())
+        BigInt::from_str(&fixed.to_string())
+            .map_err(|e| FloatError::JsSysError(e.to_string().into()))
     }
 
     /// Packs a coefficient and exponent into a `Float` in a lossless manner.

--- a/crates/float/src/lib.rs
+++ b/crates/float/src/lib.rs
@@ -492,7 +492,14 @@ impl Float {
     /// anyhow::Ok(())
     /// ```
     pub fn lte(self, b: Self) -> Result<bool, FloatError> {
-        Ok(self.lt(b)? || self.eq(b)?)
+        let Float(a) = self;
+        let Float(b) = b;
+        let calldata = DecimalFloat::lteCall { a, b }.abi_encode();
+
+        execute_call(Bytes::from(calldata), |output| {
+            let decoded = DecimalFloat::lteCall::abi_decode_returns(output.as_ref())?;
+            Ok(decoded)
+        })
     }
 
     /// Returns `true` if `self` is greater than or equal to `b`.
@@ -519,7 +526,14 @@ impl Float {
     /// anyhow::Ok(())
     /// ```
     pub fn gte(self, b: Self) -> Result<bool, FloatError> {
-        Ok(self.gt(b)? || self.eq(b)?)
+        let Float(a) = self;
+        let Float(b) = b;
+        let calldata = DecimalFloat::gteCall { a, b }.abi_encode();
+
+        execute_call(Bytes::from(calldata), |output| {
+            let decoded = DecimalFloat::gteCall::abi_decode_returns(output.as_ref())?;
+            Ok(decoded)
+        })
     }
 }
 

--- a/test_js/float.test.ts
+++ b/test_js/float.test.ts
@@ -24,17 +24,17 @@ describe('Test Float Bindings', () => {
 		});
 
 		it('should test format18 and fromFixedDecimal', () => {
-			const float = Float.fromFixedDecimal('12345', 2)?.value!;
+			const float = Float.fromFixedDecimal(12345n, 2)?.value!;
 			expect(float.format18()?.value!).toBe('123.45');
 		});
 
 		it('should test toFixedDecimal', () => {
 			const float = Float.parse('123.45')?.value!;
-			expect(float.toFixedDecimal(2)?.value!).toBe('12345');
+			expect(float.toFixedDecimal(2)?.value!).toBe(12345n);
 		});
 
 		it('should test toFixedDecimal roundtrip', () => {
-			const originalValue = '9876543210';
+			const originalValue = 9876543210n;
 			const decimals = 8;
 			const float = Float.fromFixedDecimal(originalValue, decimals)?.value!;
 			const result = float.toFixedDecimal(decimals)?.value!;


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

- lte/gte were implemented in rust instead of being bindings to solidity
- to/from fixed decimal conversion js bindings used strings instead of bigint's

## Solution

Fix the bindings

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the JavaScript API for fixed decimal conversions to use `BigInt` inputs and outputs instead of strings.

* **Bug Fixes**
  * Improved comparison methods for floating-point values to use direct contract calls, enhancing accuracy and efficiency.

* **Tests**
  * Updated tests to reflect the switch to `BigInt` for fixed decimal operations in the JavaScript API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->