### PR TITLE
wip on non error underflow div

### DIFF
--- a/crates/float/src/lib.rs
+++ b/crates/float/src/lib.rs
@@ -1510,7 +1510,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            FloatError::DecimalFloat(DecimalFloatErrors::MulDivOverflow(_))
+            FloatError::DecimalFloat(DecimalFloatErrors::DivisionByZero(_))
         ));
     }
 

--- a/src/error/ErrDecimalFloat.sol
+++ b/src/error/ErrDecimalFloat.sol
@@ -37,6 +37,9 @@ error MulDivOverflow(uint256 x, uint256 y, uint256 denominator);
 /// @dev Thrown when a maximize underflows where it is not appropriate.
 error MaximizeUnderflow(int256 signedCoefficient, int256 exponent);
 
+/// @dev Thrown when a maximize overflows where it is not appropriate.
+error MaximizeOverflow(int256 signedCoefficient, int256 exponent);
+
 /// @dev Thrown when dividing by zero.
 /// @param signedCoefficient The signed coefficient of the numerator.
 /// @param exponent The exponent of the numerator.

--- a/src/error/ErrDecimalFloat.sol
+++ b/src/error/ErrDecimalFloat.sol
@@ -33,3 +33,11 @@ error ZeroNegativePower(Float b);
 
 /// @dev Thrown when mulDiv internal to division overflows.
 error MulDivOverflow(uint256 x, uint256 y, uint256 denominator);
+
+/// @dev Thrown when a maximize underflows where it is not appropriate.
+error MaximizeUnderflow(int256 signedCoefficient, int256 exponent);
+
+/// @dev Thrown when dividing by zero.
+/// @param signedCoefficient The signed coefficient of the numerator.
+/// @param exponent The exponent of the numerator.
+error DivisionByZero(int256 signedCoefficient, int256 exponent);

--- a/src/error/ErrDecimalFloat.sol
+++ b/src/error/ErrDecimalFloat.sol
@@ -34,9 +34,6 @@ error ZeroNegativePower(Float b);
 /// @dev Thrown when mulDiv internal to division overflows.
 error MulDivOverflow(uint256 x, uint256 y, uint256 denominator);
 
-/// @dev Thrown when a maximize underflows where it is not appropriate.
-error MaximizeUnderflow(int256 signedCoefficient, int256 exponent);
-
 /// @dev Thrown when a maximize overflows where it is not appropriate.
 error MaximizeOverflow(int256 signedCoefficient, int256 exponent);
 

--- a/src/lib/format/LibFormatDecimalFloat.sol
+++ b/src/lib/format/LibFormatDecimalFloat.sol
@@ -57,7 +57,7 @@ library LibFormatDecimalFloat {
         uint256 scaleExponent;
         uint256 scale = 0;
         if (scientific) {
-            (signedCoefficient, exponent) = LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
+            (signedCoefficient, exponent) = LibDecimalFloatImplementation.maximizeFull(signedCoefficient, exponent);
 
             bool isAtLeastE76 = signedCoefficient / 1e76 != 0;
             scaleExponent = isAtLeastE76 ? uint256(76) : uint256(75);

--- a/src/lib/implementation/LibDecimalFloatImplementation.sol
+++ b/src/lib/implementation/LibDecimalFloatImplementation.sol
@@ -7,7 +7,6 @@ import {
     Log10Negative,
     Log10Zero,
     MulDivOverflow,
-    MaximizeUnderflow,
     DivisionByZero,
     MaximizeOverflow
 } from "../../error/ErrDecimalFloat.sol";
@@ -848,7 +847,7 @@ library LibDecimalFloatImplementation {
     function maximizeFull(int256 signedCoefficient, int256 exponent) internal pure returns (int256, int256) {
         (int256 trySignedCoefficient, int256 tryExponent, bool full) = maximize(signedCoefficient, exponent);
         if (!full) {
-            revert MaximizeUnderflow(signedCoefficient, exponent);
+            revert MaximizeOverflow(signedCoefficient, exponent);
         }
         return (trySignedCoefficient, tryExponent);
     }

--- a/src/lib/implementation/LibDecimalFloatImplementation.sol
+++ b/src/lib/implementation/LibDecimalFloatImplementation.sol
@@ -8,7 +8,8 @@ import {
     Log10Zero,
     MulDivOverflow,
     MaximizeUnderflow,
-    DivisionByZero
+    DivisionByZero,
+    MaximizeOverflow
 } from "../../error/ErrDecimalFloat.sol";
 import {
     LOG_TABLES,
@@ -273,6 +274,9 @@ library LibDecimalFloatImplementation {
                         }
                     }
                 }
+                if (!fullA) {
+                    revert MaximizeOverflow(signedCoefficientA, exponentA);
+                }
             }
 
             // Attempt to apply the exponent adjustment.
@@ -319,7 +323,8 @@ library LibDecimalFloatImplementation {
 
             if (underflowExponentBy > 0) {
                 if (underflowExponentBy > 76) {
-                    // This means the exponent is too small to represent.
+                    // This means the exponent is too small to represent even if
+                    // we truncate and downscale the signed coefficient.
                     return (MAXIMIZED_ZERO_SIGNED_COEFFICIENT, MAXIMIZED_ZERO_EXPONENT);
                 }
 
@@ -501,8 +506,6 @@ library LibDecimalFloatImplementation {
         // Maximizing A and B gives us similar coefficients, which simplifies
         // detecting when their exponents are too far apart to add without
         // simply ignoring one of them.
-        bool fullA;
-        bool fullB;
         (signedCoefficientA, exponentA) = maximizeFull(signedCoefficientA, exponentA);
         (signedCoefficientB, exponentB) = maximizeFull(signedCoefficientB, exponentB);
 

--- a/test/src/lib/LibDecimalFloat.sub.t.sol
+++ b/test/src/lib/LibDecimalFloat.sub.t.sol
@@ -28,10 +28,9 @@ contract LibDecimalFloatSubTest is Test {
         try this.subExternal(signedCoefficientA, exponentA, signedCoefficientB, exponentB) returns (
             int256 signedCoefficient, int256 exponent
         ) {
-            Float float = this.subExternal(a, b);
-            (Float floatImplementation, bool lossless) = LibDecimalFloat.packLossy(signedCoefficient, exponent);
-            (lossless);
-            assertTrue(float.eq(floatImplementation));
+            // Float float = this.subExternal(a, b);
+            // (int256 signedCoefficientFloat, int256 exponentFloat) = float.unpack();
+            // assertTrue(LibDecimalFloatImplementation.eq(signedCoefficient, exponent, signedCoefficientFloat, exponentFloat));
         } catch (bytes memory err) {
             vm.expectRevert(err);
             this.subExternal(a, b);

--- a/test/src/lib/LibDecimalFloat.sub.t.sol
+++ b/test/src/lib/LibDecimalFloat.sub.t.sol
@@ -28,9 +28,10 @@ contract LibDecimalFloatSubTest is Test {
         try this.subExternal(signedCoefficientA, exponentA, signedCoefficientB, exponentB) returns (
             int256 signedCoefficient, int256 exponent
         ) {
-            // Float float = this.subExternal(a, b);
-            // (int256 signedCoefficientFloat, int256 exponentFloat) = float.unpack();
-            // assertTrue(LibDecimalFloatImplementation.eq(signedCoefficient, exponent, signedCoefficientFloat, exponentFloat));
+            Float float = this.subExternal(a, b);
+            (Float floatImplementation, bool lossless) = LibDecimalFloat.packLossy(signedCoefficient, exponent);
+            (lossless);
+            assertTrue(float.eq(floatImplementation));
         } catch (bytes memory err) {
             vm.expectRevert(err);
             this.subExternal(a, b);

--- a/test/src/lib/implementation/LibDecimalFloatImplementation.add.t.sol
+++ b/test/src/lib/implementation/LibDecimalFloatImplementation.add.t.sol
@@ -152,9 +152,9 @@ contract LibDecimalFloatImplementationAddTest is Test {
         vm.assume(signedCoefficientA != 0);
         vm.assume(signedCoefficientB != 0);
 
-        (int256 normalizedSignedCoefficientA, int256 normalizedExponentA) =
+        (int256 normalizedSignedCoefficientA, int256 normalizedExponentA, bool fullA) =
             LibDecimalFloatImplementation.maximize(signedCoefficientA, exponentA);
-        (int256 expectedSignedCoefficient, int256 expectedExponent) =
+        (int256 expectedSignedCoefficient, int256 expectedExponent, bool fullExpected) =
             LibDecimalFloatImplementation.maximize(signedCoefficientB, exponentB);
 
         vm.assume(normalizedSignedCoefficientA != 0);
@@ -251,8 +251,10 @@ contract LibDecimalFloatImplementationAddTest is Test {
         int256 exponentB;
         int256 signedCoefficientAMaximized;
         int256 signedCoefficientBMaximized;
-        (signedCoefficientAMaximized, exponentA) = LibDecimalFloatImplementation.maximize(signedCoefficientA, 0);
-        (signedCoefficientBMaximized, exponentB) = LibDecimalFloatImplementation.maximize(signedCoefficientB, 0);
+        bool fullA;
+        bool fullB;
+        (signedCoefficientAMaximized, exponentA, fullA) = LibDecimalFloatImplementation.maximize(signedCoefficientA, 0);
+        (signedCoefficientBMaximized, exponentB, fullB) = LibDecimalFloatImplementation.maximize(signedCoefficientB, 0);
 
         if (signedCoefficientA == 0 || signedCoefficientB == 0) {
             exponentA = 0;

--- a/test/src/lib/implementation/LibDecimalFloatImplementation.add.t.sol
+++ b/test/src/lib/implementation/LibDecimalFloatImplementation.add.t.sol
@@ -251,10 +251,8 @@ contract LibDecimalFloatImplementationAddTest is Test {
         int256 exponentB;
         int256 signedCoefficientAMaximized;
         int256 signedCoefficientBMaximized;
-        bool fullA;
-        bool fullB;
-        (signedCoefficientAMaximized, exponentA, fullA) = LibDecimalFloatImplementation.maximize(signedCoefficientA, 0);
-        (signedCoefficientBMaximized, exponentB, fullB) = LibDecimalFloatImplementation.maximize(signedCoefficientB, 0);
+        (signedCoefficientAMaximized, exponentA) = LibDecimalFloatImplementation.maximizeFull(signedCoefficientA, 0);
+        (signedCoefficientBMaximized, exponentB) = LibDecimalFloatImplementation.maximizeFull(signedCoefficientB, 0);
 
         if (signedCoefficientA == 0 || signedCoefficientB == 0) {
             exponentA = 0;

--- a/test/src/lib/implementation/LibDecimalFloatImplementation.add.t.sol
+++ b/test/src/lib/implementation/LibDecimalFloatImplementation.add.t.sol
@@ -152,10 +152,10 @@ contract LibDecimalFloatImplementationAddTest is Test {
         vm.assume(signedCoefficientA != 0);
         vm.assume(signedCoefficientB != 0);
 
-        (int256 normalizedSignedCoefficientA, int256 normalizedExponentA, bool fullA) =
-            LibDecimalFloatImplementation.maximize(signedCoefficientA, exponentA);
-        (int256 expectedSignedCoefficient, int256 expectedExponent, bool fullExpected) =
-            LibDecimalFloatImplementation.maximize(signedCoefficientB, exponentB);
+        (int256 normalizedSignedCoefficientA, int256 normalizedExponentA) =
+            LibDecimalFloatImplementation.maximizeFull(signedCoefficientA, exponentA);
+        (int256 expectedSignedCoefficient, int256 expectedExponent) =
+            LibDecimalFloatImplementation.maximizeFull(signedCoefficientB, exponentB);
 
         vm.assume(normalizedSignedCoefficientA != 0);
         vm.assume(expectedSignedCoefficient != 0);

--- a/test/src/lib/implementation/LibDecimalFloatImplementation.div.t.sol
+++ b/test/src/lib/implementation/LibDecimalFloatImplementation.div.t.sol
@@ -36,7 +36,7 @@ contract LibDecimalFloatImplementationDivTest is Test {
 
     function testDivZero(int256 signedCoefficient, int256 exponent) external {
         exponent = bound(exponent, type(int256).min / 2, type(int256).max);
-        (int256 signedCoefficientMaximized, int256 exponentMaximized) =
+        (int256 signedCoefficientMaximized, int256 exponentMaximized, bool full) =
             LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
         if (signedCoefficient == 0) {
             vm.expectRevert(stdError.divisionError);
@@ -51,6 +51,21 @@ contract LibDecimalFloatImplementationDivTest is Test {
             );
         }
         this.divExternal(signedCoefficient, exponent, 0, 0);
+    }
+
+    function testDivMaxPositiveValue(int256 signedCoefficient, int256 exponent) external {
+        // (int256 signedCoefficientMaximized, int256 exponentMaximized) =
+        //     LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
+        // vm.expectRevert(
+        //     abi.encodeWithSelector(
+        //         MulDivOverflow.selector,
+        //         LibDecimalFloatImplementation.absUnsignedSignedCoefficient(signedCoefficientMaximized),
+        //         1e75,
+        //         0
+        //     )
+        // );
+        // this.divExternal(signedCoefficient, exponent, 1, -76);
+        LibDecimalFloatImplementation.div(signedCoefficient, exponent, type(int256).max, type(int32).max);
     }
 
     /// 1 / 3 gas by parts 10
@@ -131,7 +146,7 @@ contract LibDecimalFloatImplementationDivTest is Test {
     /// Should be possible to divide every number by 1.
     function testDivBy1(int256 signedCoefficient, int256 exponent) external pure {
         exponent = bound(exponent, type(int256).min + 76, type(int256).max);
-        (int256 expectedCoefficient, int256 expectedExponent) =
+        (int256 expectedCoefficient, int256 expectedExponent, bool full) =
             LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
 
         int256 one = 1;
@@ -146,7 +161,7 @@ contract LibDecimalFloatImplementationDivTest is Test {
 
     function testDivByNegativeOneFloat(int256 signedCoefficient, int256 exponent) external pure {
         exponent = bound(exponent, type(int256).min + 76, type(int256).max - 1);
-        (int256 expectedCoefficient, int256 expectedExponent) =
+        (int256 expectedCoefficient, int256 expectedExponent, bool full) =
             LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
         (expectedCoefficient, expectedExponent) =
             LibDecimalFloatImplementation.minus(expectedCoefficient, expectedExponent);

--- a/test/src/lib/implementation/LibDecimalFloatImplementation.div.t.sol
+++ b/test/src/lib/implementation/LibDecimalFloatImplementation.div.t.sol
@@ -7,7 +7,7 @@ import {
     LibDecimalFloatImplementation,
     EXPONENT_MIN,
     EXPONENT_MAX,
-    MulDivOverflow
+    DivisionByZero
 } from "src/lib/implementation/LibDecimalFloatImplementation.sol";
 import {THREES, ONES} from "../../../lib/LibCommonResults.sol";
 
@@ -36,35 +36,11 @@ contract LibDecimalFloatImplementationDivTest is Test {
 
     function testDivZero(int256 signedCoefficient, int256 exponent) external {
         exponent = bound(exponent, type(int256).min / 2, type(int256).max);
-        (int256 signedCoefficientMaximized, int256 exponentMaximized, bool full) =
-            LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
-        if (signedCoefficient == 0) {
-            vm.expectRevert(stdError.divisionError);
-        } else {
-            vm.expectRevert(
-                abi.encodeWithSelector(
-                    MulDivOverflow.selector,
-                    LibDecimalFloatImplementation.absUnsignedSignedCoefficient(signedCoefficientMaximized),
-                    1e75,
-                    0
-                )
-            );
-        }
+        vm.expectRevert(abi.encodeWithSelector(DivisionByZero.selector, signedCoefficient, exponent));
         this.divExternal(signedCoefficient, exponent, 0, 0);
     }
 
-    function testDivMaxPositiveValue(int256 signedCoefficient, int256 exponent) external {
-        // (int256 signedCoefficientMaximized, int256 exponentMaximized) =
-        //     LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
-        // vm.expectRevert(
-        //     abi.encodeWithSelector(
-        //         MulDivOverflow.selector,
-        //         LibDecimalFloatImplementation.absUnsignedSignedCoefficient(signedCoefficientMaximized),
-        //         1e75,
-        //         0
-        //     )
-        // );
-        // this.divExternal(signedCoefficient, exponent, 1, -76);
+    function testDivMaxPositiveValueNotRevert(int256 signedCoefficient, int256 exponent) external pure {
         LibDecimalFloatImplementation.div(signedCoefficient, exponent, type(int256).max, type(int32).max);
     }
 

--- a/test/src/lib/implementation/LibDecimalFloatImplementation.div.t.sol
+++ b/test/src/lib/implementation/LibDecimalFloatImplementation.div.t.sol
@@ -40,7 +40,7 @@ contract LibDecimalFloatImplementationDivTest is Test {
         this.divExternal(signedCoefficient, exponent, 0, 0);
     }
 
-    function testDivMaxPositiveValueNotRevert(int256 signedCoefficient, int256 exponent) external pure {
+    function testDivMaxPositiveValueDenominatorNotRevert(int256 signedCoefficient, int256 exponent) external pure {
         LibDecimalFloatImplementation.div(signedCoefficient, exponent, type(int256).max, type(int32).max);
     }
 
@@ -122,8 +122,8 @@ contract LibDecimalFloatImplementationDivTest is Test {
     /// Should be possible to divide every number by 1.
     function testDivBy1(int256 signedCoefficient, int256 exponent) external pure {
         exponent = bound(exponent, type(int256).min + 76, type(int256).max);
-        (int256 expectedCoefficient, int256 expectedExponent, bool full) =
-            LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
+        (int256 expectedCoefficient, int256 expectedExponent) =
+            LibDecimalFloatImplementation.maximizeFull(signedCoefficient, exponent);
 
         int256 one = 1;
         for (int256 oneExponent = 0; oneExponent >= -76; --oneExponent) {
@@ -137,8 +137,8 @@ contract LibDecimalFloatImplementationDivTest is Test {
 
     function testDivByNegativeOneFloat(int256 signedCoefficient, int256 exponent) external pure {
         exponent = bound(exponent, type(int256).min + 76, type(int256).max - 1);
-        (int256 expectedCoefficient, int256 expectedExponent, bool full) =
-            LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
+        (int256 expectedCoefficient, int256 expectedExponent) =
+            LibDecimalFloatImplementation.maximizeFull(signedCoefficient, exponent);
         (expectedCoefficient, expectedExponent) =
             LibDecimalFloatImplementation.minus(expectedCoefficient, expectedExponent);
 

--- a/test/src/lib/implementation/LibDecimalFloatImplementation.inv.t.sol
+++ b/test/src/lib/implementation/LibDecimalFloatImplementation.inv.t.sol
@@ -8,7 +8,6 @@ import {
     LibDecimalFloatImplementation,
     EXPONENT_MIN,
     EXPONENT_MAX,
-    MulDivOverflow,
     DivisionByZero
 } from "src/lib/implementation/LibDecimalFloatImplementation.sol";
 

--- a/test/src/lib/implementation/LibDecimalFloatImplementation.inv.t.sol
+++ b/test/src/lib/implementation/LibDecimalFloatImplementation.inv.t.sol
@@ -8,7 +8,8 @@ import {
     LibDecimalFloatImplementation,
     EXPONENT_MIN,
     EXPONENT_MAX,
-    MulDivOverflow
+    MulDivOverflow,
+    DivisionByZero
 } from "src/lib/implementation/LibDecimalFloatImplementation.sol";
 
 contract LibDecimalFloatImplementationInvTest is Test {
@@ -42,7 +43,7 @@ contract LibDecimalFloatImplementationInvTest is Test {
     }
 
     function testInv0() external {
-        vm.expectRevert(abi.encodeWithSelector(MulDivOverflow.selector, 1e76, 1e75, 0));
+        vm.expectRevert(abi.encodeWithSelector(DivisionByZero.selector, 1e76, -76));
         this.invExternal(0, 0);
     }
 }

--- a/test/src/lib/implementation/LibDecimalFloatImplementation.maximize.t.sol
+++ b/test/src/lib/implementation/LibDecimalFloatImplementation.maximize.t.sol
@@ -33,8 +33,8 @@ contract LibDecimalFloatImplementationMaximizeTest is Test {
     /// Every normalized number is maximized.
     function testMaximizedEverything(int256 signedCoefficient, int256 exponent) external pure {
         exponent = bound(exponent, EXPONENT_MIN, EXPONENT_MAX);
-        (int256 actualSignedCoefficient, int256 actualExponent, bool full) =
-            LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
+        (int256 actualSignedCoefficient, int256 actualExponent) =
+            LibDecimalFloatImplementation.maximizeFull(signedCoefficient, exponent);
         assertTrue(isMaximized(actualSignedCoefficient, actualExponent));
     }
 
@@ -44,8 +44,8 @@ contract LibDecimalFloatImplementationMaximizeTest is Test {
         int256 expectedCoefficient,
         int256 expectedExponent
     ) internal pure {
-        (int256 actualSignedCoefficient, int256 actualExponent, bool full) =
-            LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
+        (int256 actualSignedCoefficient, int256 actualExponent) =
+            LibDecimalFloatImplementation.maximizeFull(signedCoefficient, exponent);
         assertEq(actualSignedCoefficient, expectedCoefficient);
         assertEq(actualExponent, expectedExponent);
     }
@@ -74,10 +74,10 @@ contract LibDecimalFloatImplementationMaximizeTest is Test {
     /// Maximization should be idempotent.
     function testMaximizedIdempotent(int256 signedCoefficient, int256 exponent) external pure {
         exponent = bound(exponent, EXPONENT_MIN, EXPONENT_MAX);
-        (int256 maximizedSignedCoefficient, int256 maximizedExponent, bool full) =
-            LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
-        (int256 actualSignedCoefficient, int256 actualExponent, bool fullActual) =
-            LibDecimalFloatImplementation.maximize(maximizedSignedCoefficient, maximizedExponent);
+        (int256 maximizedSignedCoefficient, int256 maximizedExponent) =
+            LibDecimalFloatImplementation.maximizeFull(signedCoefficient, exponent);
+        (int256 actualSignedCoefficient, int256 actualExponent) =
+            LibDecimalFloatImplementation.maximizeFull(maximizedSignedCoefficient, maximizedExponent);
         assertEq(actualSignedCoefficient, maximizedSignedCoefficient);
         assertEq(actualExponent, maximizedExponent);
     }
@@ -85,8 +85,8 @@ contract LibDecimalFloatImplementationMaximizeTest is Test {
     /// Maximization against reference.
     function testMaximizedReference(int256 signedCoefficient, int256 exponent) external pure {
         exponent = bound(exponent, EXPONENT_MIN, EXPONENT_MAX);
-        (int256 actualSignedCoefficient, int256 actualExponent, bool fullActual) =
-            LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
+        (int256 actualSignedCoefficient, int256 actualExponent) =
+            LibDecimalFloatImplementation.maximizeFull(signedCoefficient, exponent);
         (int256 expectedSignedCoefficient, int256 expectedExponent) =
             LibDecimalFloatSlow.maximizeSlow(signedCoefficient, exponent);
         assertEq(actualSignedCoefficient, expectedSignedCoefficient);

--- a/test/src/lib/implementation/LibDecimalFloatImplementation.maximize.t.sol
+++ b/test/src/lib/implementation/LibDecimalFloatImplementation.maximize.t.sol
@@ -33,7 +33,7 @@ contract LibDecimalFloatImplementationMaximizeTest is Test {
     /// Every normalized number is maximized.
     function testMaximizedEverything(int256 signedCoefficient, int256 exponent) external pure {
         exponent = bound(exponent, EXPONENT_MIN, EXPONENT_MAX);
-        (int256 actualSignedCoefficient, int256 actualExponent) =
+        (int256 actualSignedCoefficient, int256 actualExponent, bool full) =
             LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
         assertTrue(isMaximized(actualSignedCoefficient, actualExponent));
     }
@@ -44,7 +44,7 @@ contract LibDecimalFloatImplementationMaximizeTest is Test {
         int256 expectedCoefficient,
         int256 expectedExponent
     ) internal pure {
-        (int256 actualSignedCoefficient, int256 actualExponent) =
+        (int256 actualSignedCoefficient, int256 actualExponent, bool full) =
             LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
         assertEq(actualSignedCoefficient, expectedCoefficient);
         assertEq(actualExponent, expectedExponent);
@@ -74,9 +74,9 @@ contract LibDecimalFloatImplementationMaximizeTest is Test {
     /// Maximization should be idempotent.
     function testMaximizedIdempotent(int256 signedCoefficient, int256 exponent) external pure {
         exponent = bound(exponent, EXPONENT_MIN, EXPONENT_MAX);
-        (int256 maximizedSignedCoefficient, int256 maximizedExponent) =
+        (int256 maximizedSignedCoefficient, int256 maximizedExponent, bool full) =
             LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
-        (int256 actualSignedCoefficient, int256 actualExponent) =
+        (int256 actualSignedCoefficient, int256 actualExponent, bool fullActual) =
             LibDecimalFloatImplementation.maximize(maximizedSignedCoefficient, maximizedExponent);
         assertEq(actualSignedCoefficient, maximizedSignedCoefficient);
         assertEq(actualExponent, maximizedExponent);
@@ -85,7 +85,7 @@ contract LibDecimalFloatImplementationMaximizeTest is Test {
     /// Maximization against reference.
     function testMaximizedReference(int256 signedCoefficient, int256 exponent) external pure {
         exponent = bound(exponent, EXPONENT_MIN, EXPONENT_MAX);
-        (int256 actualSignedCoefficient, int256 actualExponent) =
+        (int256 actualSignedCoefficient, int256 actualExponent, bool fullActual) =
             LibDecimalFloatImplementation.maximize(signedCoefficient, exponent);
         (int256 expectedSignedCoefficient, int256 expectedExponent) =
             LibDecimalFloatSlow.maximizeSlow(signedCoefficient, exponent);


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

- [x] what if fullA is false? do we need to change scaling? https://github.com/rainlanguage/rain.math.float/issues/131
- [x] optimize the fullB false case rescaling? https://github.com/rainlanguage/rain.math.float/issues/132
- [x] fix sub

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added explicit error types for division-by-zero and normalization overflow to improve failure reporting.

- **Bug Fixes**
  - Division now deterministically reverts on zero divisors and handles extreme operands with improved underflow/overflow behavior.
  - Formatting/scientific output now uses a stricter full-normalization path to avoid rare underflow or formatting inaccuracies.

- **Tests**
  - Tests updated to rely on full-normalization, expect the new error behaviors, and add coverage for extreme-value division.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->