### PR TITLE
feat: provide json abi as flake output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,6 +3182,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rain-math-float-wasm"
+version = "0.1.0"
+dependencies = [
+ "rain-math-float",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/float/src/lib.rs
+++ b/crates/float/src/lib.rs
@@ -24,14 +24,14 @@ use evm::execute_test_call;
 sol!(
     #![sol(all_derives)]
     DecimalFloat,
-    "../../out/DecimalFloat.sol/DecimalFloat.json"
+    env!("RAIN_MATH_FLOAT_DECIMAL_FLOAT_ABI")
 );
 
 #[cfg(test)]
 sol!(
     #![sol(all_derives)]
     TestDecimalFloat,
-    "../../out/TestDecimalFloat.sol/TestDecimalFloat.json"
+    env!("RAIN_MATH_FLOAT_TEST_DECIMAL_FLOAT_ABI")
 );
 
 #[derive(Debug, Copy, Clone, Default, Serialize, Deserialize, Hash)]

--- a/flake.nix
+++ b/flake.nix
@@ -8,9 +8,38 @@
 
   outputs = { self, flake-utils, rainix }:
     flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = rainix.pkgs.${system};
+      let
+        pkgs = rainix.pkgs.${system};
+
+        decimal-float-abi = pkgs.stdenvNoCC.mkDerivation {
+          pname = "rain-math-float-abi";
+          version = "0.1.0";
+          src = ./.;
+
+          nativeBuildInputs = [ pkgs.foundry-bin pkgs.solc_0_8_25 ];
+
+          FOUNDRY_SOLC = "${pkgs.solc_0_8_25}/bin/solc-0.8.25";
+          FOUNDRY_OFFLINE = "true";
+
+          buildPhase = ''
+            runHook preBuild
+            export HOME="$TMPDIR"
+            forge build
+            runHook postBuild
+          '';
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out
+            cp out/DecimalFloat.sol/DecimalFloat.json $out/DecimalFloat.json
+            cp out/TestDecimalFloat.sol/TestDecimalFloat.json $out/TestDecimalFloat.json
+            runHook postInstall
+          '';
+        };
       in rec {
         packages = rainix.packages.${system} // {
+          inherit decimal-float-abi;
+
           test-wasm-build = rainix.mkTask.${system} {
             name = "test-wasm-build";
             body = ''
@@ -31,7 +60,10 @@
         };
 
         devShells.default = pkgs.mkShell {
-          shellHook = rainix.devShells.${system}.default.shellHook;
+          shellHook = rainix.devShells.${system}.default.shellHook + ''
+            export RAIN_MATH_FLOAT_DECIMAL_FLOAT_ABI="$PWD/out/DecimalFloat.sol/DecimalFloat.json"
+            export RAIN_MATH_FLOAT_TEST_DECIMAL_FLOAT_ABI="$PWD/out/TestDecimalFloat.sol/TestDecimalFloat.json"
+          '';
           packages = [ packages.test-wasm-build packages.test-js-bindings ];
           inputsFrom = [ rainix.devShells.${system}.default ];
         };


### PR DESCRIPTION
Closes RAI-329

## Motivation

The ABI paths for `DecimalFloat` and `TestDecimalFloat` were hardcoded as relative file paths, making the build brittle and tightly coupled to a specific directory layout. This prevented reproducible builds in Nix environments where output paths are managed differently.

## Solution

A Nix derivation (`decimal-float-abi`) is introduced to compile the Solidity contracts and produce the ABI JSON files as a proper build output. The hardcoded paths in `lib.rs` are replaced with environment variables (`RAIN_MATH_FLOAT_DECIMAL_FLOAT_ABI` and `RAIN_MATH_FLOAT_TEST_DECIMAL_FLOAT_ABI`) resolved at compile time via `env!()`. These variables are automatically set in the dev shell to point to the local build output, and the Nix derivation sets them to the compiled artifacts during CI/package builds. A new `rain-math-float-wasm` package entry is also added to the lockfile.

##  