### PR TITLE
chore: cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 node_modules
 .env
 .fixes
+.pre-commit-config.yaml

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -75,16 +91,58 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1769324704,
-        "narHash": "sha256-aef15vEgiMEls1hTMt46rJuKNSO2cIOfiP99patq9yc=",
+        "lastModified": 1773213477,
+        "narHash": "sha256-Pv1Z3QqGkSGEUV+9pM5vYIiI7VJo7Tfm6ZmR+JSp1zo=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "e830409ba1bdecdc5ef9a1ec92660fc2da9bc68d",
+        "rev": "3c73daa86c823d706824fd9bbcb85aa23fd0f668",
         "type": "github"
       },
       "original": {
         "owner": "shazow",
         "repo": "foundry.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1774104215,
+        "narHash": "sha256-EAtviqz0sEAxdHS4crqu7JGR5oI3BwaqG0mw7CmXkO8=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "f799ae951fde0627157f40aec28dec27b22076d0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "rainix",
+          "git-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -120,11 +178,27 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1769364508,
-        "narHash": "sha256-Wy8EVYSLq5Fb/rYH3LRxAMCnW75f9hOg2562AXVFmPk=",
+        "lastModified": 1770073757,
+        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1776017067,
+        "narHash": "sha256-oEp8fqJweZd5doqvH/aBAtc6NzZh+fh0tOhR09gQXck=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6077bc4fb29be43d525984f63b69d37b9b1e62fe",
+        "rev": "a5a7cf16648d79134eb4da0e3354b08913917b2f",
         "type": "github"
       },
       "original": {
@@ -133,7 +207,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1744536153,
         "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
@@ -149,13 +223,13 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
-        "lastModified": 1766653575,
-        "narHash": "sha256-TPgxCS7+hWc4kPhzkU5dD2M5UuPhLuuaMNZ/IpwKQvI=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3c1016e6acd16ad96053116d0d3043029c9e2649",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {
@@ -169,17 +243,18 @@
       "inputs": {
         "flake-utils": "flake-utils_2",
         "foundry": "foundry",
-        "nixpkgs": "nixpkgs_2",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-old": "nixpkgs-old",
         "rust-overlay": "rust-overlay",
         "solc": "solc"
       },
       "locked": {
-        "lastModified": 1770274701,
-        "narHash": "sha256-00kymonJVHUtCBBaXMqmVF3b78dtDdXJg8K7P2U9lbA=",
+        "lastModified": 1776019532,
+        "narHash": "sha256-0aMnHCZ2fR0+ZwuRHFouYYUQqYL/dSp5cOgka0m6vE4=",
         "owner": "rainprotocol",
         "repo": "rainix",
-        "rev": "51c1c74a0e6bc5c49336b02ef97684d01e1e8ad4",
+        "rev": "9babaac787d1e1119609b0d89c33a6b42249c066",
         "type": "github"
       },
       "original": {
@@ -196,14 +271,14 @@
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1769309768,
-        "narHash": "sha256-AbOIlNO+JoqRJkK1VrnDXhxuX6CrdtIu2hSuy4pxi3g=",
+        "lastModified": 1773216618,
+        "narHash": "sha256-iZlowevS+xKLGOXtZwpIrz3SWe7PtoGUfEeVZNib+WE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "140c9dc582cb73ada2d63a2180524fcaa744fad5",
+        "rev": "07d7dc6fcc5eae76b4fb0e19d4afd939437bec97",
         "type": "github"
       },
       "original": {
@@ -215,15 +290,15 @@
     "solc": {
       "inputs": {
         "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_5",
         "solc-macos-amd64-list-json": "solc-macos-amd64-list-json"
       },
       "locked": {
-        "lastModified": 1768831671,
-        "narHash": "sha256-0mmlYRtZK+eomevkQCCH7PL8QlSuALZQsjLroCWGE08=",
+        "lastModified": 1772085240,
+        "narHash": "sha256-+NEcuhT2A0QQumVx9Ze6g2iuNicyuW028Jq/HUJHGh4=",
         "owner": "hellwolf",
         "repo": "solc.nix",
-        "rev": "80ad871b93d15c7bccf71617f78f73c2d291a9c7",
+        "rev": "d3cc119973e484ea366f4b997b404bb00d7829ca",
         "type": "github"
       },
       "original": {
@@ -235,13 +310,13 @@
     "solc-macos-amd64-list-json": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-P+ZslplK4cQ/wnV/wykVKb+yTCviI0eylA3sk9uHmRo=",
+        "narHash": "sha256-oEiXc95EghuYCudzkPA9XBFOnMdgWFfTO2/4XUfSTpc=",
         "type": "file",
-        "url": "https://github.com/argotorg/solc-bin/raw/a11f1ad/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/argotorg/solc-bin/raw/a11f1ad/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
       }
     },
     "systems": {

--- a/test/src/lib/deploy/LibDecimalFloatDeploy.t.sol
+++ b/test/src/lib/deploy/LibDecimalFloatDeploy.t.sol
@@ -10,10 +10,12 @@ import {LibDataContract} from "rain.datacontract/lib/LibDataContract.sol";
 
 /// @dev Pinned ETH L1 fork block. Forking at "latest" races RPC state
 /// propagation: the node can advertise a freshly-finalized head before its
-/// state is queryable, causing flakes. Any post-Zoltu-proxy archive-served
-/// block works for these deploys; this constant pins a stable historical
-/// block.
-uint256 constant FORK_BLOCK_NUMBER = 22000000;
+/// state is queryable, causing flakes. The CI `CI_FORK_ETH_RPC_URL` is a
+/// non-archive node that prunes state past a recent retention window, so
+/// the pin must stay near the head — older blocks fail with "state at
+/// block #N is pruned". This block is the head as of pinning; bump
+/// periodically as state ages out.
+uint256 constant FORK_BLOCK_NUMBER = 25000000;
 
 contract LibDecimalFloatDeployTest is Test {
     function testDeployAddress() external {

--- a/test/src/lib/deploy/LibDecimalFloatDeploy.t.sol
+++ b/test/src/lib/deploy/LibDecimalFloatDeploy.t.sol
@@ -15,7 +15,7 @@ import {LibDataContract} from "rain.datacontract/lib/LibDataContract.sol";
 /// the pin must stay near the head — older blocks fail with "state at
 /// block #N is pruned". This block is the head as of pinning; bump
 /// periodically as state ages out.
-uint256 constant FORK_BLOCK_NUMBER = 25000000;
+uint256 constant FORK_BLOCK_NUMBER = 25055000;
 
 contract LibDecimalFloatDeployTest is Test {
     function testDeployAddress() external {

--- a/test/src/lib/deploy/LibDecimalFloatDeploy.t.sol
+++ b/test/src/lib/deploy/LibDecimalFloatDeploy.t.sol
@@ -8,9 +8,16 @@ import {LibDecimalFloatDeploy} from "src/lib/deploy/LibDecimalFloatDeploy.sol";
 import {DecimalFloat} from "src/concrete/DecimalFloat.sol";
 import {LibDataContract} from "rain.datacontract/lib/LibDataContract.sol";
 
+/// @dev Pinned ETH L1 fork block. Forking at "latest" races RPC state
+/// propagation: the node can advertise a freshly-finalized head before its
+/// state is queryable, causing flakes. Any post-Zoltu-proxy archive-served
+/// block works for these deploys; this constant pins a stable historical
+/// block.
+uint256 constant FORK_BLOCK_NUMBER = 22000000;
+
 contract LibDecimalFloatDeployTest is Test {
     function testDeployAddress() external {
-        vm.createSelectFork(vm.envString("CI_FORK_ETH_RPC_URL"));
+        vm.createSelectFork(vm.envString("CI_FORK_ETH_RPC_URL"), FORK_BLOCK_NUMBER);
         address deployedAddress = LibRainDeploy.deployZoltu(type(DecimalFloat).creationCode);
 
         assertEq(deployedAddress, LibDecimalFloatDeploy.ZOLTU_DEPLOYED_DECIMAL_FLOAT_ADDRESS);
@@ -26,7 +33,7 @@ contract LibDecimalFloatDeployTest is Test {
     }
 
     function testDeployAddressLogTables() external {
-        vm.createSelectFork(vm.envString("CI_FORK_ETH_RPC_URL"));
+        vm.createSelectFork(vm.envString("CI_FORK_ETH_RPC_URL"), FORK_BLOCK_NUMBER);
         bytes memory logTables = LibDataContract.contractCreationCode(LibDecimalFloatDeploy.combinedTables());
         address deployedAddress = LibRainDeploy.deployZoltu(logTables);
 


### PR DESCRIPTION
## Summary

- Bump `flake.lock`.
- Add `.pre-commit-config.yaml` to `.gitignore` (locally generated, not part of the repo's tracked config).

## Test plan

- [x] `git status` shows only the intended changes