### PR TITLE
ci: publish to soldeer on v* tags

### DIFF
--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -1,0 +1,8 @@
+name: Publish to Soldeer
+on:
+  push:
+    tags: ["v*"]
+jobs:
+  publish:
+    uses: rainlanguage/rainix/.github/workflows/publish-soldeer.yaml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

One-line wrapper over rainix's `publish-soldeer.yaml` reusable. Pushes the project to soldeer.xyz on every `v*` tag.

Package name defaults to `rain-math-float` (rainix derives it from repo name with `.` → `-`).

## Prerequisites

- [ ] Project `rain-math-float` exists on soldeer.xyz (registry rejects pushes to nonexistent projects).
- [ ] `SOLDEER_API_TOKEN` org secret is set (workflow inherits secrets).

## Test plan

- [ ] Push a `v*` tag and confirm the workflow succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)