### PR TITLE
ci: use rainix manual-sol-artifacts reusable; factor LibEtchLogTables

### DIFF
--- a/.github/workflows/manual-sol-artifacts.yaml
+++ b/.github/workflows/manual-sol-artifacts.yaml
@@ -11,45 +11,7 @@ on:
           - decimal-float
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: nixbuild/nix-quick-install-action@v30
-        with:
-          nix_conf: |
-            keep-env-derivations = true
-            keep-outputs = true
-      - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
-        with:
-          # restore and save a cache using this key
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          # if there's no cache hit, restore a cache by this prefix
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-          # collect garbage until the Nix store size (in bytes) is at most this number
-          # before trying to save a new cache
-          # 1G = 1073741824
-          gc-max-store-size-linux: 1G
-      - run: nix develop -c forge soldeer install
-      - run: nix develop -c forge selectors up --all
-      # `--skip-simulation` is only needed for the decimal-float suite, whose
-      # constructor reads the log-tables data contract via `extcodecopy` —
-      # simulation can't see that address until it's actually deployed. The
-      # log-tables suite has no such cross-deploy dependency, so simulation
-      # stays on for it as a safety net against a broken artifact.
-      - run: nix develop -c forge script script/Deploy.sol:Deploy -vvvvv --slow --broadcast --verify ${{ inputs.suite == 'decimal-float' && '--skip-simulation' || '' }}
-        env:
-          DEPLOYMENT_SUITE: ${{ inputs.suite }}
-          DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}
-          ARBITRUM_RPC_URL: ${{ secrets.RPC_URL_ARBITRUM_FORK || vars.RPC_URL_ARBITRUM_FORK || '' }}
-          BASE_RPC_URL: ${{ secrets.RPC_URL_BASE_FORK || vars.RPC_URL_BASE_FORK || '' }}
-          BASE_SEPOLIA_RPC_URL: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK || vars.RPC_URL_BASE_SEPOLIA_FORK || '' }}
-          FLARE_RPC_URL: ${{ secrets.RPC_URL_FLARE_FORK || vars.RPC_URL_FLARE_FORK || '' }}
-          POLYGON_RPC_URL: ${{ secrets.RPC_URL_POLYGON_FORK || vars.RPC_URL_POLYGON_FORK || '' }}
-          CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY || vars.CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY || '' }}
-          CI_DEPLOY_BASE_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_BASE_ETHERSCAN_API_KEY || vars.CI_DEPLOY_BASE_ETHERSCAN_API_KEY || '' }}
-          CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY || vars.CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY || '' }}
-          CI_DEPLOY_FLARE_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_FLARE_ETHERSCAN_API_KEY || vars.CI_DEPLOY_FLARE_ETHERSCAN_API_KEY || '' }}
-          CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY || vars.CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY || '' }}
+    uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-artifacts.yaml@main
+    with:
+      suite: ${{ inputs.suite }}
+    secrets: inherit

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -7,6 +7,7 @@ import {LibDataContract} from "rain-datacontract-0.1.0/src/lib/LibDataContract.s
 import {LibDecimalFloatDeploy} from "../src/lib/deploy/LibDecimalFloatDeploy.sol";
 import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
 import {DecimalFloat} from "../src/concrete/DecimalFloat.sol";
+import {LibEtchLogTables} from "./lib/LibEtchLogTables.sol";
 
 /// @dev Hash of the "log-tables" deployment suite string. When the
 /// `DEPLOYMENT_SUITE` env var is set to "log-tables", the script deploys the
@@ -38,6 +39,17 @@ contract Deploy is Script {
                 sDepCodeHashes
             );
         } else if (suite == DEPLOYMENT_SUITE_CONTRACT) {
+            // DecimalFloat's constructor calls
+            // LibDecimalFloatDeploy.checkLogTablesDeployed(), which reads
+            // extcodesize/codehash at ZOLTU_DEPLOYED_LOG_TABLES_ADDRESS.
+            // The simulation pass runs before the broadcast pass, so if
+            // log-tables hasn't actually been deployed yet on this chain
+            // the simulation reverts. Plant the runtime bytecode locally
+            // so simulation matches the post-broadcast on-chain state.
+            if (LibDecimalFloatDeploy.ZOLTU_DEPLOYED_LOG_TABLES_ADDRESS.code.length == 0) {
+                LibEtchLogTables.etchLogTables(vm);
+            }
+
             address[] memory decimalFloatDependencies = new address[](1);
             decimalFloatDependencies[0] = LibDecimalFloatDeploy.ZOLTU_DEPLOYED_LOG_TABLES_ADDRESS;
             LibRainDeploy.deployAndBroadcast(

--- a/script/lib/LibEtchLogTables.sol
+++ b/script/lib/LibEtchLogTables.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: LicenseRef-DCL-1.0
+// SPDX-FileCopyrightText: Copyright (c) 2020 Rain Open Source Software Ltd
+pragma solidity ^0.8.25;
+
+import {Vm} from "forge-std-1.16.1/src/Vm.sol";
+import {LibDataContract} from "rain-datacontract-0.1.0/src/lib/LibDataContract.sol";
+import {LibDecimalFloatDeploy} from "src/lib/deploy/LibDecimalFloatDeploy.sol";
+
+/// @notice Shared logic for planting the log-tables data contract at its
+/// Zoltu-deterministic address inside a forge VM. Used by `script/Deploy.sol`
+/// (so the decimal-float simulation pass can pass the constructor's codehash
+/// check before log-tables exists on-chain) and by tests that need
+/// `DecimalFloat` operations to work without a real on-chain deploy.
+library LibEtchLogTables {
+    /// @notice Deploys the log-tables data contract to a temporary address,
+    /// copies its runtime code, and etches that runtime at
+    /// `LibDecimalFloatDeploy.ZOLTU_DEPLOYED_LOG_TABLES_ADDRESS` so the
+    /// codehash matches `LibDecimalFloatDeploy.LOG_TABLES_DATA_CONTRACT_HASH`.
+    function etchLogTables(Vm vm) internal {
+        bytes memory tables = LibDecimalFloatDeploy.combinedTables();
+        bytes memory creationCode = LibDataContract.contractCreationCode(tables);
+        address temp;
+        assembly ("memory-safe") {
+            temp := create(0, add(creationCode, 0x20), mload(creationCode))
+        }
+        require(temp != address(0), "log tables etch deploy failed");
+        vm.etch(LibDecimalFloatDeploy.ZOLTU_DEPLOYED_LOG_TABLES_ADDRESS, temp.code);
+    }
+}

--- a/test/abstract/LogTest.sol
+++ b/test/abstract/LogTest.sol
@@ -7,6 +7,7 @@ pragma solidity =0.8.25;
 import {Test, console2} from "forge-std-1.16.1/src/Test.sol";
 import {DataContractMemoryContainer, LibDataContract} from "rain-datacontract-0.1.0/src/lib/LibDataContract.sol";
 import {LibDecimalFloatDeploy} from "src/lib/deploy/LibDecimalFloatDeploy.sol";
+import {LibEtchLogTables} from "script/lib/LibEtchLogTables.sol";
 
 abstract contract LogTest is Test {
     using LibDataContract for DataContractMemoryContainer;
@@ -15,19 +16,10 @@ abstract contract LogTest is Test {
 
     /// Etch the log tables runtime at the Zoltu-deterministic deployment
     /// address used by the production `DecimalFloat` contract. Without this,
-    /// the `*Deployed` tests below would `extcodecopy` from an empty address,
-    /// have both the external helper and the deployed contract agree on
-    /// garbage, and pass without verifying anything (the H01-class failure
-    /// mode this PR fixes in production).
+    /// the deployed tests below would `extcodecopy` from an empty address
+    /// while the external helper does the same, both agreeing on garbage.
     function setUp() public virtual {
-        bytes memory tables = LibDecimalFloatDeploy.combinedTables();
-        bytes memory creationCode = LibDataContract.contractCreationCode(tables);
-        address temp;
-        assembly ("memory-safe") {
-            temp := create(0, add(creationCode, 0x20), mload(creationCode))
-        }
-        require(temp != address(0), "log tables deploy failed in LogTest.setUp");
-        vm.etch(LibDecimalFloatDeploy.ZOLTU_DEPLOYED_LOG_TABLES_ADDRESS, temp.code);
+        LibEtchLogTables.etchLogTables(vm);
         assertEq(
             LibDecimalFloatDeploy.ZOLTU_DEPLOYED_LOG_TABLES_ADDRESS.codehash,
             LibDecimalFloatDeploy.LOG_TABLES_DATA_CONTRACT_HASH,

--- a/test/src/concrete/DecimalFloat.constructor.t.sol
+++ b/test/src/concrete/DecimalFloat.constructor.t.sol
@@ -5,8 +5,8 @@ pragma solidity =0.8.25;
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {DecimalFloat} from "src/concrete/DecimalFloat.sol";
 import {LibDecimalFloatDeploy} from "src/lib/deploy/LibDecimalFloatDeploy.sol";
-import {LibDataContract} from "rain-datacontract-0.1.0/src/lib/LibDataContract.sol";
 import {LogTablesNotDeployed} from "src/error/ErrDecimalFloat.sol";
+import {LibEtchLogTables} from "script/lib/LibEtchLogTables.sol";
 
 /// Direct tests for the `DecimalFloat` constructor's log-tables guard. These
 /// tests deliberately do NOT inherit `LogTest` so the table address is empty
@@ -48,14 +48,7 @@ contract DecimalFloatConstructorTest is Test {
     /// With the correct log tables runtime etched at the expected address,
     /// the constructor succeeds.
     function testConstructorSucceedsWhenLogTablesPresent() external {
-        bytes memory tables = LibDecimalFloatDeploy.combinedTables();
-        bytes memory creationCode = LibDataContract.contractCreationCode(tables);
-        address temp;
-        assembly ("memory-safe") {
-            temp := create(0, add(creationCode, 0x20), mload(creationCode))
-        }
-        require(temp != address(0), "log tables deploy failed in test setup");
-        vm.etch(LibDecimalFloatDeploy.ZOLTU_DEPLOYED_LOG_TABLES_ADDRESS, temp.code);
+        LibEtchLogTables.etchLogTables(vm);
         // Should NOT revert.
         DecimalFloat decimalFloat = new DecimalFloat();
         assertTrue(address(decimalFloat) != address(0));
@@ -68,19 +61,12 @@ contract DecimalFloatConstructorTest is Test {
     /// on the codehash check.
     function testConstructorMutation() external {
         // First half: correct etch — must succeed.
-        bytes memory tables = LibDecimalFloatDeploy.combinedTables();
-        bytes memory creationCode = LibDataContract.contractCreationCode(tables);
-        address temp;
-        assembly ("memory-safe") {
-            temp := create(0, add(creationCode, 0x20), mload(creationCode))
-        }
-        require(temp != address(0), "log tables deploy failed in mutation setup");
-        vm.etch(LibDecimalFloatDeploy.ZOLTU_DEPLOYED_LOG_TABLES_ADDRESS, temp.code);
+        LibEtchLogTables.etchLogTables(vm);
         new DecimalFloat();
 
         // Mutation: replace the tables runtime with the same length of zero
         // bytes. The codehash now mismatches LOG_TABLES_DATA_CONTRACT_HASH.
-        bytes memory zeros = new bytes(temp.code.length);
+        bytes memory zeros = new bytes(LibDecimalFloatDeploy.ZOLTU_DEPLOYED_LOG_TABLES_ADDRESS.code.length);
         vm.etch(LibDecimalFloatDeploy.ZOLTU_DEPLOYED_LOG_TABLES_ADDRESS, zeros);
         bytes32 zeroBytesCodehash = keccak256(zeros);
         vm.expectRevert(


### PR DESCRIPTION
## Summary
- Replace per-repo manual-sol-artifacts.yaml with a thin wrapper around the upstream rainix-manual-sol-artifacts.yaml reusable; suite stays a workflow_dispatch choice.
- Add a simulation precondition in script/Deploy.sol for the decimal-float suite: etch the log-tables runtime at ZOLTU_DEPLOYED_LOG_TABLES_ADDRESS when its code is empty, so the constructor's codehash check passes during the pre-broadcast simulation pass.
- Factor the etch-deploy-and-copy pattern into script/lib/LibEtchLogTables.sol, replacing inline duplicates in LogTest.setUp and DecimalFloatConstructorTest.

## Test plan
- compile clean locally
- constructor tests pass
- LogTest-derived tests still pass under the new setUp path
- After merge, run the workflow on this branch with suite=decimal-float to confirm the simulation precondition lets the run reach broadcast

Generated with Claude Code.