### PR TITLE
chore: prep crates.io publish for rain-math-float

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 .env
 .fixes
 .pre-commit-config.yaml
+.claude

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4611,8 +4611,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-utils"
-version = "0.0.10"
-source = "git+https://github.com/rainlanguage/rain.wasm?rev=06990d85a0b7c55378a1c8cca4dd9e2bc34a596a#06990d85a0b7c55378a1c8cca4dd9e2bc34a596a"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbbd367f4921f4e3291bc0e789de16303a2dcfcf8b3b11e0c21f4ed4cefba93"
 dependencies = [
  "js-sys",
  "paste",
@@ -4626,8 +4627,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-utils-macros"
-version = "0.0.5"
-source = "git+https://github.com/rainlanguage/rain.wasm?rev=06990d85a0b7c55378a1c8cca4dd9e2bc34a596a#06990d85a0b7c55378a1c8cca4dd9e2bc34a596a"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fed599c9e990172750babd2e8b880c70bb796b170ff3f1ae0b8aed16279303a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 version = "0.1.0"
-license = "CAL-1.0"
+license = "LicenseRef-DCL-1.0"
 homepage = "https://github.com/rainlanguage/rain.math.float"
 repository = "https://github.com/rainlanguage/rain.math.float"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,15 @@ resolver = "2"
 edition = "2024"
 version = "0.1.0"
 license = "CAL-1.0"
-homepage = "https://github.com/rainprotocol/rain.math.float"
+homepage = "https://github.com/rainlanguage/rain.math.float"
+repository = "https://github.com/rainlanguage/rain.math.float"
 
 [workspace.dependencies]
 alloy = { version = "1.0.9", features = ["sol-types", "json-rpc"] }
 revm = { version = "25.0.0", default-features = false, features = [
-    "portable",
-    "std",
-    "tracer",
+  "portable",
+  "std",
+  "tracer",
 ] }
 thiserror = "2.0.12"
 proptest = "1.7.0"

--- a/crates/float/Cargo.toml
+++ b/crates/float/Cargo.toml
@@ -3,7 +3,9 @@ name = "rain-math-float"
 version = "0.1.0"
 edition = "2021"
 license = "LicenseRef-DCL-1.0"
+description = "Decimal floating-point arithmetic for Rainlang / DeFi smart contracts. Packs a 224-bit signed coefficient and 32-bit signed exponent into a single bytes32, with exact decimal semantics (no NaN, Infinity, or negative zero — operations error on nonsense). Rust bindings delegate to the Solidity reference via an in-memory EVM so on-chain and off-chain results match exactly."
 homepage = "https://github.com/rainlanguage/rain.math.float"
+repository = "https://github.com/rainlanguage/rain.math.float"
 
 [lib]
 crate-type = ["rlib"]
@@ -12,22 +14,22 @@ crate-type = ["rlib"]
 alloy = { version = "1.0.9", features = ["sol-types", "json-rpc"] }
 thiserror = "2.0.12"
 serde = "1.0.219"
-wasm-bindgen-utils = { git = "https://github.com/rainlanguage/rain.wasm", rev = "06990d85a0b7c55378a1c8cca4dd9e2bc34a596a" }
+wasm-bindgen-utils = "0.0.11"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 revm = { version = "25.0.0", default-features = false, features = [
-    "c-kzg",
-    "portable",
-    "std",
-    "tracer",
+  "c-kzg",
+  "portable",
+  "std",
+  "tracer",
 ] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 revm = { version = "25.0.0", default-features = false, features = [
-    "kzg-rs",
-    "portable",
-    "std",
-    "tracer",
+  "kzg-rs",
+  "portable",
+  "std",
+  "tracer",
 ] }
 getrandom = { version = "0.2.11", features = ["js", "js-sys"] }
 


### PR DESCRIPTION
## Summary
Closes #205.

- Cargo.toml (workspace): fix homepage (\`rainprotocol\` → \`rainlanguage\`), add \`repository\`
- crates/float/Cargo.toml (rain-math-float): add \`description\`, add \`repository\`, swap \`wasm-bindgen-utils\` git pin for the freshly-published \`"0.0.11"\` on crates.io
- .gitignore: split a joined \`.pre-commit-config.yaml\` / \`.claude\` entry caused by a missing newline; gitignore \`.claude\`

## Test plan
- cargo build with the new dep resolves and compiles
- After merge: \`cargo publish -p rain-math-float\`

Generated with Claude Code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace configuration and metadata
  * Adjusted dependency management setup

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.math.float/pull/206)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->