### PR TITLE
ci: add cargo-publish workflow for rain-math-float

### DIFF
--- a/.github/workflows/cargo-publish.yaml
+++ b/.github/workflows/cargo-publish.yaml
@@ -1,0 +1,79 @@
+name: Cargo Crate Release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    if: ${{ github.ref == 'refs/heads/main' && !startsWith(github.event.head_commit.message, 'Cargo Crate Release') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.PUBLISHER_SSH_KEY }}
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+      - run: nix develop -c forge soldeer install
+      - run: nix develop -c cargo test -p rain-math-float
+      # Hash the crate tarball that would be published.
+      - name: Get New Hash
+        run: |
+          NEW_HASH=$(nix develop -c cargo package -p rain-math-float --allow-dirty --quiet --list | LC_ALL=C sort | sha256sum | cut -d' ' -f1)
+          echo "NEW_HASH=$NEW_HASH" >> $GITHUB_ENV
+      # Hash the file list of the latest published version on crates.io.
+      - name: Get Old Hash
+        run: |
+          OLD_VERSION=$(curl -fsSL "https://crates.io/api/v1/crates/rain-math-float" | python3 -c "import sys, json; print(json.load(sys.stdin)['crate']['max_version'])" 2>/dev/null || echo "none")
+          if [ "$OLD_VERSION" = "none" ]; then
+            OLD_HASH="none"
+          else
+            curl -fsSL "https://crates.io/api/v1/crates/rain-math-float/$OLD_VERSION/download" -o /tmp/old.crate
+            OLD_HASH=$(tar -tzf /tmp/old.crate 2>/dev/null | LC_ALL=C sort | sha256sum | cut -d' ' -f1)
+          fi
+          echo "OLD_HASH=$OLD_HASH" >> $GITHUB_ENV
+      - name: Git Config
+        if: ${{ env.OLD_HASH != env.NEW_HASH }}
+        run: |
+          git config --global user.email "${{ secrets.CI_GIT_EMAIL }}"
+          git config --global user.name "${{ secrets.CI_GIT_USER }}"
+      - name: Publish to crates.io
+        if: ${{ env.OLD_HASH != env.NEW_HASH }}
+        run: nix develop -c cargo release --no-confirm --execute --no-tag -p rain-math-float alpha
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Get Version
+        if: ${{ env.OLD_HASH != env.NEW_HASH }}
+        run: echo "NEW_VERSION=v$(cargo pkgid -p rain-math-float | cut -d@ -f2)" >> $GITHUB_ENV
+      - name: Push Commit
+        if: ${{ env.OLD_HASH != env.NEW_HASH }}
+        run: git push origin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Tag
+        if: ${{ env.OLD_HASH != env.NEW_HASH }}
+        run: git tag crate-${{ env.NEW_VERSION }}
+      - name: Push Tag
+        if: ${{ env.OLD_HASH != env.NEW_HASH }}
+        run: git push origin crate-${{ env.NEW_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create GitHub Release
+        if: ${{ env.OLD_HASH != env.NEW_HASH }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: crate-${{ env.NEW_VERSION }}
+          name: Cargo Crate Release ${{ env.NEW_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Auto-publish \`rain-math-float\` to crates.io on every push to main, mirroring the npm-package-release.yaml pattern.

Hash-skip detection:
- New hash: \`cargo package -p rain-math-float --list | sort | sha256sum\` — file list of the would-be-published \`.crate\`.
- Old hash: download the latest published version's \`.crate\` from crates.io and hash its file list the same way.
- If different, bump version via \`cargo release alpha --execute --no-tag\` (alpha prerelease), publish to crates.io, tag \`crate-v<new-version>\`, push, GitHub release.
- Commits made by this workflow are skipped via the \`!startsWith('Cargo Crate Release')\` guard, same shape as the npm release.

Uses \`nix-community/cache-nix-action@v6\` instead of the FlakeHub cache action — rainlanguage isn't enrolled with FlakeHub.

## Required repo secrets
- \`CARGO_REGISTRY_TOKEN\` — crates.io publish token
- \`PUBLISHER_SSH_KEY\` — SSH key with push to this repo
- \`CI_GIT_EMAIL\`, \`CI_GIT_USER\` — author identity for version-bump commit

## Test plan
- Merge → first run on main publishes alpha version of rain-math-float to crates.io.
- Subsequent merges that don't change the crate contents skip cleanly.

Generated with Claude Code.