### PR TITLE
chore: re-sync Cargo.toml with crates.io + use PUBLISH_PRIVATE_KEY

### DIFF
--- a/.github/workflows/cargo-publish.yaml
+++ b/.github/workflows/cargo-publish.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ssh-key: ${{ secrets.PUBLISHER_SSH_KEY }}
+          ssh-key: ${{ secrets.PUBLISH_PRIVATE_KEY }}
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,7 +3168,7 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rain-math-float"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 dependencies = [
  "alloy",
  "anyhow",

--- a/crates/float/Cargo.toml
+++ b/crates/float/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rain-math-float"
-version = "0.1.1-alpha.1"
+version = "0.1.1-alpha.2"
 edition = "2021"
 license = "LicenseRef-DCL-1.0"
 description = "Decimal floating-point arithmetic for Rainlang / DeFi smart contracts. Packs a 224-bit signed coefficient and 32-bit signed exponent into a single bytes32, with exact decimal semantics (no NaN, Infinity, or negative zero — operations error on nonsense). Rust bindings delegate to the Solidity reference via an in-memory EVM so on-chain and off-chain results match exactly."


### PR DESCRIPTION
## Summary
\`rain-math-float 0.1.1-alpha.2\` was published to crates.io by the Cargo Crate Release workflow after #208 landed, but the post-publish push of the version-bump commit was rejected by branch protection:

> remote: error: GH013: Repository rule violations found for refs/heads/main.
> ! [remote rejected] main -> main (push declined due to repository rule violations)

The npm release workflow uses \`PUBLISH_PRIVATE_KEY\` (the deploy key configured with bypass). My workflow used \`PUBLISHER_SSH_KEY\` (copied from rain.wasm) which doesn't have bypass on this repo.

- Swap \`PUBLISHER_SSH_KEY\` → \`PUBLISH_PRIVATE_KEY\` in cargo-publish.yaml.
- Bump \`crates/float/Cargo.toml\` to \`0.1.1-alpha.2\` to re-sync main with crates.io.

## Test plan
- After merge, the cargo-publish workflow's hash-skip should not re-publish (Cargo.toml content matches the latest published metadata).
- Next meaningful change triggers \`0.1.1-alpha.3\` and the version-bump commit lands cleanly via the bypass key.

Generated with Claude Code.