### PR TITLE
fix(ci): pass --no-publish to cargo release bump step

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Bump Cargo version
         if: ${{ steps.cargo.outputs.changed == 'true' }}
         run: |
-          nix develop -c cargo release --no-confirm --execute --no-tag --no-push -p rain-math-float alpha
+          nix develop -c cargo release --no-confirm --execute --no-tag --no-push --no-publish -p rain-math-float alpha
           echo "CARGO_VERSION=v$(cargo pkgid -p rain-math-float | cut -d@ -f2)" >> $GITHUB_ENV
       # NPM second — npm version edits files but doesn't commit.
       - name: Bump NPM version


### PR DESCRIPTION
The bump step in package-release.yaml ran cargo release without --no-publish, so it tried to publish to crates.io. CARGO_REGISTRY_TOKEN is only set on the separate Publish step further down, so the bump step failed with 'no token found, please run cargo login'.

Run 25759994597 hit this. Add --no-publish so the bump step only bumps the version + commits; the dedicated Publish step uploads with the token set.