### PR TITLE
fix(soldeer): ignore .envrc and .prettierignore on publish

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Bump Cargo version
         if: ${{ steps.cargo.outputs.changed == 'true' }}
         run: |
-          nix develop -c cargo release --no-confirm --execute --no-tag --no-push -p rain-math-float alpha
+          nix develop -c cargo release --no-confirm --execute --no-tag --no-push --no-publish -p rain-math-float alpha
           echo "CARGO_VERSION=v$(cargo pkgid -p rain-math-float | cut -d@ -f2)" >> $GITHUB_ENV
       # NPM second — npm version edits files but doesn't commit.
       - name: Bump NPM version

--- a/.soldeerignore
+++ b/.soldeerignore
@@ -1,11 +1,13 @@
 .DS_Store
 .coderabbitai.yaml
+.envrc
 .gas-snapshot
 .git
 .github
 .gitignore
 .gitmodules
 .pre-commit-config.yaml
+.prettierignore
 .soldeerignore
 .vscode
 CLAUDE.md


### PR DESCRIPTION
## Summary
- Add `.envrc` and `.prettierignore` to `.soldeerignore`.
- Both are tracked dotfiles that trip soldeer's `check_dotfiles` warning. CI has no TTY for the confirmation prompt, so soldeer errors with `error during IO operation for "": not connected` and the publish fails (run 25800427603).

## Test plan
- [x] `forge soldeer push rain-math-float~0.1.0 --dry-run` locally — zip no longer contains either file.
- [ ] Re-tag v0.1.0 after merge; publish-soldeer.yaml succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Updated package release workflow configuration
  - Refined repository ignore patterns for configuration files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.math.float/pull/214)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->