### PR TITLE
test: pin fromFixedDecimalLosslessPacked(x, 0) bitwise identity (I06)

### DIFF
--- a/test/src/lib/LibDecimalFloat.decimalLossless.t.sol
+++ b/test/src/lib/LibDecimalFloat.decimalLossless.t.sol
@@ -33,6 +33,18 @@ contract LibDecimalFloatDecimalLosslessTest is Test {
         return float.toFixedDecimalLossless(decimals);
     }
 
+    /// `fromFixedDecimalLosslessPacked(value, 0)` is the bitwise identity
+    /// `bytes32(value)` for every `value` that fits in `int224`. Pinned
+    /// here so the float library owns the invariant — callers (e.g. the
+    /// Rainlang EVM opcodes for `block.number`, `block.timestamp`,
+    /// `chainid`) can write the raw integer to the stack as a documented
+    /// optimization without re-discovering or re-asserting it.
+    function testFromFixedDecimalLosslessPackedZeroDecimalsIsIdentity(uint256 value) external pure {
+        value = bound(value, 0, uint256(int256(type(int224).max)));
+        Float result = LibDecimalFloat.fromFixedDecimalLosslessPacked(value, 0);
+        assertEq(Float.unwrap(result), bytes32(value));
+    }
+
     function testFromFixedDecimalLosslessMem(uint256 value, uint8 decimals) external {
         value = bound(value, 0, uint256(int256(type(int224).max)));
         (,, bool losslessPreflight) = LibDecimalFloat.fromFixedDecimalLossy(value, decimals);


### PR DESCRIPTION
## Summary
- Adds a fuzz test asserting \`Float.unwrap(fromFixedDecimalLosslessPacked(value, 0)) == bytes32(value)\` for every value in \`[0, type(int224).max]\` (5096 runs).
- Owns the invariant in this library so downstream callers (Rainlang's \`block.number\` / \`block.timestamp\` / \`chainid\` opcodes) can write the raw integer straight to the stack as a documented optimization without re-asserting it in their own \`referenceFn\` tests.

Related: rainlanguage/rainlang#491

## Test plan
- [x] Test passes (5096 fuzz runs).
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for decimal conversion functions to ensure bitwise preservation of values under specific conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.math.float/pull/215)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->