### PR TITLE
chore: release rain-math-float 0.1.1

### DIFF
--- a/crates/float/Cargo.toml
+++ b/crates/float/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rain-math-float"
-version = "0.1.1-alpha.4"
+version = "0.1.1"
 edition = "2021"
 license = "LicenseRef-DCL-1.0"
 description = "Decimal floating-point arithmetic for Rainlang / DeFi smart contracts. Packs a 224-bit signed coefficient and 32-bit signed exponent into a single bytes32, with exact decimal semantics (no NaN, Infinity, or negative zero — operations error on nonsense). Rust bindings delegate to the Solidity reference via an in-memory EVM so on-chain and off-chain results match exactly."


### PR DESCRIPTION
## Summary

- Bumps \`crates/float/Cargo.toml\` from \`0.1.1-alpha.4\` → \`0.1.1\`.
- Prep for first stable \`rain-math-float\` publish to crates.io.

Resolves #216.

## Test plan

- [ ] CI green.
- [ ] After merge: tag \`v0.1.1\` and run \`cargo publish -p rain-math-float\`.