### PR TITLE
chore: sync Cargo.lock to rain-math-float 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,7 +3168,7 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rain-math-float"
-version = "0.1.1-alpha.4"
+version = "0.1.1"
 dependencies = [
  "alloy",
  "anyhow",


### PR DESCRIPTION
Cargo.lock still pinned to 0.1.1-alpha.4 after #217 — caused the autopublish workflow to fail at `cargo release` with 'uncommitted changes detected' because CI rewrote the lockfile before cargo-release runs.

Tracks #216.