### PR TITLE
ci: float autopublish bumps stable patch, not alpha

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -70,13 +70,13 @@ jobs:
       - name: Bump Cargo version
         if: ${{ steps.cargo.outputs.changed == 'true' }}
         run: |
-          nix develop -c cargo release --no-confirm --execute --no-tag --no-push --no-publish -p rain-math-float alpha
+          nix develop -c cargo release --no-confirm --execute --no-tag --no-push --no-publish -p rain-math-float patch
           echo "CARGO_VERSION=v$(cargo pkgid -p rain-math-float | cut -d@ -f2)" >> $GITHUB_ENV
       # NPM second — npm version edits files but doesn't commit.
       - name: Bump NPM version
         if: ${{ steps.npm.outputs.changed == 'true' }}
         run: |
-          NEW=$(npm version prerelease --preid alpha --no-git-tag-version)
+          NEW=$(npm version patch --no-git-tag-version)
           echo "NPM_VERSION=$NEW" >> $GITHUB_ENV
           git add package.json package-lock.json
           git commit -m "Package Release npm-${NEW}"


### PR DESCRIPTION
Each push to main currently auto-bumps to a new alpha (`cargo release alpha` / `npm version prerelease --preid alpha`). Switches both to stable patch bumps.