### PR TITLE
ci: fix npm token secret name

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -97,7 +97,7 @@ jobs:
         if: ${{ steps.npm.outputs.changed == 'true' }}
         uses: JS-DevTools/npm-publish@v3
         with:
-          token: ${{ secrets.NPM_TOKEN }}
+          token: ${{ secrets.NPM_PUBLISH_PRIVATE_TOKEN }}
           access: public
           package: float_npm_package_${{ env.NPM_VERSION }}.tgz
       # Cargo publish


### PR DESCRIPTION
The npm-publish step referenced `secrets.NPM_TOKEN` but the actual configured secret is `NPM_PUBLISH_PRIVATE_TOKEN`. Without this, the workflow failed at the NPM publish step with 404, and crates.io publish never ran because it's gated after.