### PR TITLE
ci: modernize on latest rainix + slim shells

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -34,7 +34,9 @@ jobs:
       - name: Install soldeer dependencies
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
       - name: Test JS/TS bindings
-        run: nix develop -c test-js-bindings
+        run: |
+          nix develop github:rainlanguage/rainix#rust-shell -c bash -c \
+            "npm install --no-check && npm run build && npm test"
       - name: Cargo test
         run: nix develop github:rainlanguage/rainix#rust-shell -c cargo test -p rain-math-float
       - name: Git Config

--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -34,9 +34,7 @@ jobs:
       - name: Install soldeer dependencies
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
       - name: Test JS/TS bindings
-        run: |
-          nix develop github:rainlanguage/rainix#rust-shell -c bash -c \
-            "npm install --no-check && npm run build && npm test"
+        run: nix develop -c test-js-bindings
       - name: Cargo test
         run: nix develop github:rainlanguage/rainix#rust-shell -c cargo test -p rain-math-float
       - name: Git Config

--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -31,16 +31,16 @@ jobs:
         with:
           node-version: 22
           cache: "npm"
-      - run: nix develop -c forge soldeer install
+      - name: Install soldeer dependencies
+        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
       - name: Test JS/TS bindings
         run: nix develop -c test-js-bindings
       - name: Cargo test
-        run: nix develop -c cargo test -p rain-math-float
+        run: nix develop github:rainlanguage/rainix#rust-shell -c cargo test -p rain-math-float
       - name: Git Config
         run: |
           git config --global user.email "${{ secrets.CI_GIT_EMAIL }}"
           git config --global user.name "${{ secrets.CI_GIT_USER }}"
-      # NPM hash detection
       - name: NPM hashes
         id: npm
         run: |
@@ -50,11 +50,10 @@ jobs:
           echo "old=$OLD" >> $GITHUB_OUTPUT
           echo "new=$NEW" >> $GITHUB_OUTPUT
           if [ "$OLD" = "$NEW" ]; then echo "changed=false" >> $GITHUB_OUTPUT; else echo "changed=true" >> $GITHUB_OUTPUT; fi
-      # Cargo hash detection
       - name: Cargo hashes
         id: cargo
         run: |
-          NEW=$(nix develop -c cargo package -p rain-math-float --allow-dirty --quiet --list | LC_ALL=C sort | sha256sum | cut -d' ' -f1)
+          NEW=$(nix develop github:rainlanguage/rainix#rust-shell -c cargo package -p rain-math-float --allow-dirty --quiet --list | LC_ALL=C sort | sha256sum | cut -d' ' -f1)
           OLD_VERSION=$(curl -fsSL "https://crates.io/api/v1/crates/rain-math-float" | python3 -c "import sys, json; print(json.load(sys.stdin)['crate']['max_version'])" 2>/dev/null || echo "none")
           if [ "$OLD_VERSION" = "none" ]; then
             OLD="none"
@@ -65,14 +64,11 @@ jobs:
           echo "old=$OLD" >> $GITHUB_OUTPUT
           echo "new=$NEW" >> $GITHUB_OUTPUT
           if [ "$OLD" = "$NEW" ]; then echo "changed=false" >> $GITHUB_OUTPUT; else echo "changed=true" >> $GITHUB_OUTPUT; fi
-      # Cargo first — cargo-release refuses to run if the working tree is
-      # dirty, and it makes its own commit.
       - name: Bump Cargo version
         if: ${{ steps.cargo.outputs.changed == 'true' }}
         run: |
-          nix develop -c cargo release --no-confirm --execute --no-tag --no-push --no-publish -p rain-math-float patch
-          echo "CARGO_VERSION=v$(cargo pkgid -p rain-math-float | cut -d@ -f2)" >> $GITHUB_ENV
-      # NPM second — npm version edits files but doesn't commit.
+          nix develop github:rainlanguage/rainix#rust-shell -c cargo release --no-confirm --execute --no-tag --no-push --no-publish -p rain-math-float patch
+          echo "CARGO_VERSION=v$(nix develop github:rainlanguage/rainix#rust-shell -c cargo pkgid -p rain-math-float | cut -d@ -f2)" >> $GITHUB_ENV
       - name: Bump NPM version
         if: ${{ steps.npm.outputs.changed == 'true' }}
         run: |
@@ -87,25 +83,23 @@ jobs:
           if [ -n "${{ env.CARGO_VERSION }}" ]; then git tag crate-${{ env.CARGO_VERSION }}; fi
           git push origin main
           git push origin --tags
-      # NPM publish
       - name: NPM pack
         if: ${{ steps.npm.outputs.changed == 'true' }}
         run: |
           TARBALL=$(npm pack --silent)
           mv "$TARBALL" float_npm_package_${{ env.NPM_VERSION }}.tgz
+      - name: Publish to crates.io
+        if: ${{ steps.cargo.outputs.changed == 'true' }}
+        run: nix develop github:rainlanguage/rainix#rust-shell -c cargo publish -p rain-math-float
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Publish to NPM
         if: ${{ steps.npm.outputs.changed == 'true' }}
         uses: JS-DevTools/npm-publish@v3
         with:
-          token: ${{ secrets.NPM_TOKEN }}
+          token: ${{ secrets.NPM_PUBLISH_PRIVATE_TOKEN }}
           access: public
           package: float_npm_package_${{ env.NPM_VERSION }}.tgz
-      # Cargo publish
-      - name: Publish to crates.io
-        if: ${{ steps.cargo.outputs.changed == 'true' }}
-        run: nix develop -c cargo publish -p rain-math-float
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: GitHub Release (npm)
         if: ${{ steps.npm.outputs.changed == 'true' }}
         uses: softprops/action-gh-release@v2

--- a/flake.lock
+++ b/flake.lock
@@ -91,11 +91,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1773213477,
-        "narHash": "sha256-Pv1Z3QqGkSGEUV+9pM5vYIiI7VJo7Tfm6ZmR+JSp1zo=",
+        "lastModified": 1778486972,
+        "narHash": "sha256-iuy/TbK9AbghEld2VSFuxyAF30LkOGUUdtrvixLfE7M=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "3c73daa86c823d706824fd9bbcb85aa23fd0f668",
+        "rev": "db117ae95a77b9ead24137c3ccb28896ae4fa4ec",
         "type": "github"
       },
       "original": {
@@ -111,11 +111,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1774104215,
-        "narHash": "sha256-EAtviqz0sEAxdHS4crqu7JGR5oI3BwaqG0mw7CmXkO8=",
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "f799ae951fde0627157f40aec28dec27b22076d0",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
         "type": "github"
       },
       "original": {
@@ -160,22 +160,6 @@
         "type": "indirect"
       }
     },
-    "nixpkgs-old": {
-      "locked": {
-        "lastModified": 1749104371,
-        "narHash": "sha256-m2NmOPd6XgBiskmUq/BS9Xxuf3z0ebnGVfSKNAO5NEM=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "48975d7f9b9960ed33c4e8561bcce20cc0c2de5b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "48975d7f9b9960ed33c4e8561bcce20cc0c2de5b",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1770073757,
@@ -194,11 +178,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1776017067,
-        "narHash": "sha256-oEp8fqJweZd5doqvH/aBAtc6NzZh+fh0tOhR09gQXck=",
+        "lastModified": 1778656924,
+        "narHash": "sha256-lKVrom9wOmpC3i7m+uBoGaBdW0PfH3QbLRG1XmuC6YA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a5a7cf16648d79134eb4da0e3354b08913917b2f",
+        "rev": "4ba039de0909446943c07e2b42bd2f0f4507072e",
         "type": "github"
       },
       "original": {
@@ -225,11 +209,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1771923393,
-        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
+        "lastModified": 1777641297,
+        "narHash": "sha256-WNGcmeOZ8Tr9dq6ztCspYbzWFswr2mPebM9LpsfGxPk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
+        "rev": "c6d65881c5624c9cae5ea6cedef24699b0c0a4c0",
         "type": "github"
       },
       "original": {
@@ -245,20 +229,19 @@
         "foundry": "foundry",
         "git-hooks-nix": "git-hooks-nix",
         "nixpkgs": "nixpkgs_3",
-        "nixpkgs-old": "nixpkgs-old",
         "rust-overlay": "rust-overlay",
         "solc": "solc"
       },
       "locked": {
-        "lastModified": 1778445525,
-        "narHash": "sha256-1oNxd9cKgHuKWj9+NUxWCYqY6jtKkk0gWXiPi2dhd7A=",
-        "owner": "rainprotocol",
+        "lastModified": 1779209879,
+        "narHash": "sha256-9x9V41PmF1RQlM5R6SV6xbgVnP+qgW9mUyRC50RQ9G8=",
+        "owner": "rainlanguage",
         "repo": "rainix",
-        "rev": "edcd45a05ce301bcf2c04a1f8256a79e091f10ad",
+        "rev": "d444279bc7346a6f4f7bd4a0b7f9900523b8f00e",
         "type": "github"
       },
       "original": {
-        "owner": "rainprotocol",
+        "owner": "rainlanguage",
         "repo": "rainix",
         "type": "github"
       }
@@ -274,11 +257,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1773216618,
-        "narHash": "sha256-iZlowevS+xKLGOXtZwpIrz3SWe7PtoGUfEeVZNib+WE=",
+        "lastModified": 1778642276,
+        "narHash": "sha256-bhk4lawR4ZnFhPtamB5WkCyvfgyZmsEUbWfT/3FRxFY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "07d7dc6fcc5eae76b4fb0e19d4afd939437bec97",
+        "rev": "77265d2dc1e61b2abfd3b1d6609dbb66fe75e0a5",
         "type": "github"
       },
       "original": {
@@ -294,11 +277,11 @@
         "solc-macos-amd64-list-json": "solc-macos-amd64-list-json"
       },
       "locked": {
-        "lastModified": 1772085240,
-        "narHash": "sha256-+NEcuhT2A0QQumVx9Ze6g2iuNicyuW028Jq/HUJHGh4=",
+        "lastModified": 1777817996,
+        "narHash": "sha256-iI71iUhD7THLibl3w1JcQEhHmTwZMxChi70RTe33BAo=",
         "owner": "hellwolf",
         "repo": "solc.nix",
-        "rev": "d3cc119973e484ea366f4b997b404bb00d7829ca",
+        "rev": "e3cf898cb804d5c0e5474b378a300fe8942e67d6",
         "type": "github"
       },
       "original": {
@@ -310,13 +293,13 @@
     "solc-macos-amd64-list-json": {
       "flake": false,
       "locked": {
-        "narHash": "sha256-oEiXc95EghuYCudzkPA9XBFOnMdgWFfTO2/4XUfSTpc=",
+        "narHash": "sha256-zzwwHA2qPotv7yp8mK7+y9BZhm7ytuFeCJVvKBBdBn4=",
         "type": "file",
-        "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/902dfaf/macosx-amd64/list.json"
       },
       "original": {
         "type": "file",
-        "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
+        "url": "https://github.com/argotorg/solc-bin/raw/902dfaf/macosx-amd64/list.json"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Flake for development workflows.";
 
   inputs = {
-    rainix.url = "github:rainprotocol/rainix";
+    rainix.url = "github:rainlanguage/rainix";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
- Bumps rainix flake input from `rainprotocol/rainix` to `rainlanguage/rainix` and updates flake.lock.
- package-release.yaml: routes cargo/sol steps through upstream slim shells (sol-shell, rust-shell) for faster cold starts. test-js-bindings keeps the local default shell since it consumes a local nix task.
- package-release.yaml: cargo publish runs before npm publish so a broken npm token cannot block crates.io. Also fixes the npm secret name (NPM_PUBLISH_PRIVATE_TOKEN — matches the configured org secret). Supersedes the targeted secret-name fix in #220.