### PR TITLE
Bump wasm-bindgen-utils to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,10 +2315,12 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -3178,6 +3180,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "wasm-bindgen",
  "wasm-bindgen-utils",
 ]
 
@@ -4540,48 +4543,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.103",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4589,31 +4576,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn 2.0.103",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-utils"
-version = "0.0.11"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbbd367f4921f4e3291bc0e789de16303a2dcfcf8b3b11e0c21f4ed4cefba93"
+checksum = "6ec45201ec48a021de21357beca43a1c93669e68eeae5deca5e3ba6b4b4fd4d6"
 dependencies = [
  "js-sys",
  "paste",
@@ -4627,9 +4614,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-utils-macros"
-version = "0.0.6"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fed599c9e990172750babd2e8b880c70bb796b170ff3f1ae0b8aed16279303a"
+checksum = "d5bf3e098464ba4e518a659f81794d58c043b8d144f8c29c11fbb488d75264f4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4652,9 +4639,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/float/Cargo.toml
+++ b/crates/float/Cargo.toml
@@ -14,7 +14,11 @@ crate-type = ["rlib"]
 alloy = { version = "1.0.9", features = ["sol-types", "json-rpc"] }
 thiserror = "2.0.12"
 serde = "1.0.219"
-wasm-bindgen-utils = "0.0.11"
+# wasm-bindgen must be a direct dependency: the #[wasm_bindgen] macro emits
+# `::wasm_bindgen` paths, and without a direct dep on the crate they fail to
+# resolve and the macro recurses without bound on opaque-class structs (Float).
+wasm-bindgen = "0.2.122"
+wasm-bindgen-utils = "0.1.2"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 revm = { version = "25.0.0", default-features = false, features = [


### PR DESCRIPTION
Moves `wasm-bindgen-utils` from `0.0.11` to `0.1.2` so downstream consumers (raindex, rain.metadata) resolve a **single** utils copy. `0.0.x` and `0.1.x` are semver-incompatible, so a mismatched tree otherwise produces two preludes and a `missing try_from_js_value_ref` ABI mismatch when raindex pulls `Float` in.

### Changes
- `crates/float/Cargo.toml`: `wasm-bindgen-utils` `0.0.11` → `0.1.2`.
- Add `wasm-bindgen = "0.2.122"` as a **direct** dependency.
- `Cargo.lock`: wasm-bindgen family `0.2.100` → `0.2.122` (utils 0.1.2 requires `>=0.2.93`); `serde` stays `1.0.219`.

### Why the direct wasm-bindgen dep
Without it, builds fail with an *unbounded* `recursion limit reached while expanding #[wasm_bindgen]` on the opaque-class structs (`Float`, `FromFixedDecimalLossyResult`) — the compiler keeps suggesting `recursion_limit = "256" → 512 → 1024 …` forever. The `#[wasm_bindgen]` macro emits `::wasm_bindgen` paths; when the crate is only transitive those paths don't resolve and the macro re-expands without bound. Declaring `wasm-bindgen` directly (as `rain.metadata`'s cli crate already does) fixes it with **no source changes** and **no recursion_limit hack**.

### Verification
- `cargo check` native + `wasm32-unknown-unknown`: clean.
- `cargo test -p rain-math-float`: 76 + 36 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to newer versions for improved compatibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.math.float/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->