### PR TITLE
Box FloatError::DecimalFloat to shrink the error enum

### DIFF
--- a/crates/float/src/error.rs
+++ b/crates/float/src/error.rs
@@ -21,7 +21,7 @@ pub enum FloatError {
     #[error(transparent)]
     AlloySolTypes(#[from] alloy::sol_types::Error),
     #[error("Decimal Float error: {0:?}")]
-    DecimalFloat(DecimalFloat::DecimalFloatErrors),
+    DecimalFloat(Box<DecimalFloat::DecimalFloatErrors>),
     #[error("Decimal Float error selector: {0:?}")]
     DecimalFloatSelector(Result<DecimalFloatErrorSelector, FixedBytes<4>>),
     #[error(transparent)]

--- a/crates/float/src/evm.rs
+++ b/crates/float/src/evm.rs
@@ -86,7 +86,7 @@ where
         }
         ExecutionResult::Revert { output, .. } => {
             if let Ok(error) = DecimalFloat::DecimalFloatErrors::abi_decode(output.as_ref()) {
-                return Err(FloatError::DecimalFloat(error));
+                return Err(FloatError::DecimalFloat(Box::new(error)));
             }
 
             Err(FloatError::Revert(output))

--- a/crates/float/src/lib.rs
+++ b/crates/float/src/lib.rs
@@ -1379,7 +1379,7 @@ mod tests {
         let err = Float::parse("1e3000000000".to_string()).unwrap_err();
         assert!(matches!(
             err,
-            FloatError::DecimalFloat(DecimalFloatErrors::ExponentOverflow(_))
+            FloatError::DecimalFloat(e) if matches!(*e, DecimalFloatErrors::ExponentOverflow(_))
         ));
     }
 
@@ -1477,7 +1477,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            FloatError::DecimalFloat(DecimalFloatErrors::ExponentOverflow(_))
+            FloatError::DecimalFloat(e) if matches!(*e, DecimalFloatErrors::ExponentOverflow(_))
         ));
     }
 
@@ -1495,7 +1495,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            FloatError::DecimalFloat(DecimalFloatErrors::ExponentOverflow(_))
+            FloatError::DecimalFloat(e) if matches!(*e, DecimalFloatErrors::ExponentOverflow(_))
         ));
     }
 
@@ -1750,7 +1750,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            FloatError::DecimalFloat(DecimalFloatErrors::DivisionByZero(_))
+            FloatError::DecimalFloat(e) if matches!(*e, DecimalFloatErrors::DivisionByZero(_))
         ));
     }
 
@@ -1763,7 +1763,7 @@ mod tests {
         let err = (near_max_exp * one_e_two).unwrap_err();
         assert!(matches!(
             err,
-            FloatError::DecimalFloat(DecimalFloatErrors::ExponentOverflow(_))
+            FloatError::DecimalFloat(e) if matches!(*e, DecimalFloatErrors::ExponentOverflow(_))
         ));
     }
 
@@ -1776,7 +1776,7 @@ mod tests {
         let err = (near_max_exp / one_e_neg_hundred).unwrap_err();
         assert!(matches!(
             err,
-            FloatError::DecimalFloat(DecimalFloatErrors::ExponentOverflow(_))
+            FloatError::DecimalFloat(e) if matches!(*e, DecimalFloatErrors::ExponentOverflow(_))
         ));
     }
 
@@ -1791,7 +1791,7 @@ mod tests {
         let err = (near_min_exp * one_e_neg_three).unwrap_err();
         assert!(matches!(
             err,
-            FloatError::DecimalFloat(DecimalFloatErrors::ExponentUnderflow(_))
+            FloatError::DecimalFloat(e) if matches!(*e, DecimalFloatErrors::ExponentUnderflow(_))
         ));
     }
 
@@ -1820,7 +1820,7 @@ mod tests {
         let err = Float::from_fixed_decimal(U256::MAX, 1).unwrap_err();
         assert!(matches!(
             err,
-            FloatError::DecimalFloat(DecimalFloatErrors::LossyConversionToFloat(_))
+            FloatError::DecimalFloat(e) if matches!(*e, DecimalFloatErrors::LossyConversionToFloat(_))
         ));
     }
 


### PR DESCRIPTION
## Summary
- `DecimalFloatErrors` is 104 bytes, making `FloatError` 112 bytes.
- That trips `clippy::result_large_err` in downstream consumers (e.g. raindex) whose aggregate error enums embed `FloatError` — once embedded, their enums exceed the 128-byte threshold.
- Boxing the `DecimalFloat` variant drops `FloatError` to ~64 bytes. Consumers' `match`/`Display` are unaffected (deref through `Box`).

## Test plan
- [ ] CI green (autopublish will release the next patch, 0.1.7).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling memory management in the float processing system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rain.math.float/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->