### PR TITLE
chore: latest rainix + soldeer re-lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -233,11 +233,11 @@
         "solc": "solc"
       },
       "locked": {
-        "lastModified": 1779209879,
-        "narHash": "sha256-9x9V41PmF1RQlM5R6SV6xbgVnP+qgW9mUyRC50RQ9G8=",
+        "lastModified": 1780287289,
+        "narHash": "sha256-eZ74zj6VwotSmT1kXImwA2yX0el0pZthcgNjg7j/AyQ=",
         "owner": "rainlanguage",
         "repo": "rainix",
-        "rev": "d444279bc7346a6f4f7bd4a0b7f9900523b8f00e",
+        "rev": "f22d4dcaca61717e33eac65e7b09b9a82f604c1f",
         "type": "github"
       },
       "original": {

--- a/foundry.toml
+++ b/foundry.toml
@@ -40,7 +40,7 @@ forge-std = "1.16.1"
 "rain-solmem" = "0.1.3"
 "rain-string" = "0.2.0"
 "rain-datacontract" = "0.1.0"
-"rain-deploy" = "0.1.2"
+"rain-deploy" = "0.1.3"
 "rain-sol-codegen" = "0.1.0"
 
 [soldeer]

--- a/remappings.txt
+++ b/remappings.txt
@@ -2,6 +2,7 @@
 forge-std-1.16.1/=dependencies/forge-std-1.16.1/
 rain-datacontract-0.1.0/=dependencies/rain-datacontract-0.1.0/
 rain-deploy-0.1.2/=dependencies/rain-deploy-0.1.2/
+rain-deploy-0.1.3/=dependencies/rain-deploy-0.1.3/
 rain-sol-codegen-0.1.0/=dependencies/rain-sol-codegen-0.1.0/
 rain-solmem-0.1.3/=dependencies/rain-solmem-0.1.3/
 rain-string-0.2.0/=dependencies/rain-string-0.2.0/

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -5,7 +5,7 @@ pragma solidity =0.8.25;
 import {Script} from "forge-std-1.16.1/src/Script.sol";
 import {LibDataContract} from "rain-datacontract-0.1.0/src/lib/LibDataContract.sol";
 import {LibDecimalFloatDeploy} from "../src/lib/deploy/LibDecimalFloatDeploy.sol";
-import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.3/src/lib/LibRainDeploy.sol";
 import {DecimalFloat} from "../src/concrete/DecimalFloat.sol";
 import {LibEtchLogTables} from "./lib/LibEtchLogTables.sol";
 

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -21,9 +21,9 @@ integrity = "f2e43fcbe27e7251ff981285271eec0a5ad49e1425dd02213f8a03df404f6670"
 
 [[dependencies]]
 name = "rain-deploy"
-version = "0.1.2"
-url = "https://soldeer-revisions.s3.amazonaws.com/rain-deploy/0_1_2_09-05-2026_19:49:20_rain.zip"
-checksum = "94d3daf2f9f90062d2e676077c2b4ccd2bdd66201665a2209e98016e155f619a"
+version = "0.1.3"
+url = "https://soldeer-revisions.s3.amazonaws.com/rain-deploy/0_1_3_20-05-2026_13:02:35_rain.zip"
+checksum = "6e9a7a1562ee2766a1cc3a4a077b853ec628a3070b282e6e9102a252f2a6a5b5"
 integrity = "10bff708d9e5d8b77655b8a8fc0c755cef8e3fc876cc3ff100425d27b08294a0"
 
 [[dependencies]]

--- a/test/src/lib/deploy/LibDecimalFloatDeploy.t.sol
+++ b/test/src/lib/deploy/LibDecimalFloatDeploy.t.sol
@@ -3,7 +3,7 @@
 pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
-import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.3/src/lib/LibRainDeploy.sol";
 import {LibDecimalFloatDeploy} from "src/lib/deploy/LibDecimalFloatDeploy.sol";
 import {DecimalFloat} from "src/concrete/DecimalFloat.sol";
 import {LibDataContract} from "rain-datacontract-0.1.0/src/lib/LibDataContract.sol";

--- a/test/src/lib/deploy/LibDecimalFloatDeployProd.t.sol
+++ b/test/src/lib/deploy/LibDecimalFloatDeployProd.t.sol
@@ -4,7 +4,7 @@ pragma solidity =0.8.25;
 
 import {Test} from "forge-std-1.16.1/src/Test.sol";
 import {LibDecimalFloatDeploy} from "src/lib/deploy/LibDecimalFloatDeploy.sol";
-import {LibRainDeploy} from "rain-deploy-0.1.2/src/lib/LibRainDeploy.sol";
+import {LibRainDeploy} from "rain-deploy-0.1.3/src/lib/LibRainDeploy.sol";
 
 /// @title LibDecimalFloatDeployProdTest
 /// @notice Verifies that both the log tables data contract and the DecimalFloat


### PR DESCRIPTION
Bumps rainix to latest and re-locks soldeer deps.

- `rainix.url` -> `github:rainlanguage/rainix`, `nix flake update rainix`
- soldeer deps bumped to latest registry versions where behind, then re-locked
- verified via `nix develop` (latest rainix dev shell)

🤖 Generated with [Claude Code](https://claude.com/claude-code)