### PR TITLE
ci: add soldeer to rainix-autopublish, drop manual publish-soldeer

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -9,4 +9,5 @@ jobs:
     with:
       crate: rain-math-float
       npm-package: "@rainlanguage/float"
+      soldeer-package: rain-math-float
     secrets: inherit

--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -1,8 +1,0 @@
-name: Publish to Soldeer
-on:
-  push:
-    tags: ["v*"]
-jobs:
-  publish:
-    uses: rainlanguage/rainix/.github/workflows/publish-soldeer.yaml@main
-    secrets: inherit

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,3 +1,7 @@
+[package]
+name = "rain-math-float"
+version = "0.1.1"
+
 [profile.default]
 src = 'src'
 out = 'out'


### PR DESCRIPTION
Part of removing the manual `publish-soldeer` reusable from rainix. Adds `soldeer-package: rain-math-float` to the existing `package-release.yaml` (rainix-autopublish) and `[package].version = 0.1.1` (current registry release) to foundry.toml; deletes the tag-driven `publish-soldeer.yaml`. No publish fires from this PR.