### PR TITLE
test: pin pow round-trip second-leg revert

### DIFF
--- a/test/src/lib/LibDecimalFloat.pow.t.sol
+++ b/test/src/lib/LibDecimalFloat.pow.t.sol
@@ -6,6 +6,7 @@ import {LogTest} from "../../abstract/LogTest.sol";
 
 import {LibDecimalFloat, Float} from "src/lib/LibDecimalFloat.sol";
 import {ZeroNegativePower, PowNegativeBase} from "src/error/ErrDecimalFloat.sol";
+import {WithTargetExponentOverflow} from "src/lib/implementation/LibDecimalFloatImplementation.sol";
 import {console2} from "forge-std-1.16.1/src/Test.sol";
 
 contract LibDecimalFloatPowTest is LogTest {
@@ -164,6 +165,35 @@ contract LibDecimalFloatPowTest is LogTest {
 
     function powExternal(Float a, Float b) external returns (Float) {
         return a.pow(b, logTables());
+    }
+
+    /// Pins the concrete counterexample surfaced by `testRoundTripFuzzPow`
+    /// where the first leg `a.pow(b)` succeeds but the round-trip leg
+    /// `c.pow(b.inv())` reverts with `WithTargetExponentOverflow`. A tiny
+    /// coefficient combined with the large inverted exponent produces an
+    /// unrepresentable rescale target during the round-trip. The fuzz test
+    /// absorbs this in a try/catch as "can't round-trip this input"; this named
+    /// test pins exactly which leg reverts and with which error, so a
+    /// regression that shifts the revert boundary surfaces here instead of
+    /// being silently swallowed by the fuzz catch.
+    function testRoundTripSecondLegRevert() external {
+        Float a = Float.wrap(bytes32(uint256(1)));
+        Float b = Float.wrap(bytes32(0xea5a58dfdcc79c60ac38b8284569e4519fda5eaaffec2a3d22027a4af1969e13));
+
+        // First leg succeeds.
+        Float c = this.powExternal(a, b);
+
+        // Round-trip leg reverts with the exact rescale-overflow error.
+        Float inv = b.inv();
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                WithTargetExponentOverflow.selector,
+                int256(2696051936649033486196409040598252262955326698850935392994226984449),
+                int256(363177628),
+                int256(0)
+            )
+        );
+        this.powExternal(c, inv);
     }
 
     function testRoundTripFuzzPow(Float a, Float b) external {


### PR DESCRIPTION
## Summary

Adds a dedicated concrete test `testRoundTripSecondLegRevert` next to `testRoundTripFuzzPow` in `test/src/lib/LibDecimalFloat.pow.t.sol`, pinning the pow round-trip second-leg revert path that the fuzz test currently absorbs in a try/catch.

The test constructs the exact counterexample surfaced by fuzzing:

- `a = bytes32(1)`, `b = bytes32(0xea5a58dfdcc79c60ac38b8284569e4519fda5eaaffec2a3d22027a4af1969e13)`

and asserts:

1. The first leg `a.pow(b)` succeeds.
2. The round-trip leg `c.pow(b.inv())` reverts with the exact `WithTargetExponentOverflow(2696051936649033486196409040598252262955326698850935392994226984449, 363177628, 0)` selector and args.

## Why

A tiny coefficient combined with the large inverted exponent produces an unrepresentable rescale target during the round-trip. The fuzz test treats this as "can't round-trip this input" and silently catches it. This named test pins exactly which leg reverts and with which error, so a regression that shifts the revert boundary (which inputs revert vs round-trip cleanly) surfaces in a named test instead of being absorbed by the fuzz catch.

## Verification

- `forge test --mt testRoundTripSecondLegRevert` → PASS (the asserted error selector and args match the live revert exactly).
- Full `test/src/lib/LibDecimalFloat.pow.t.sol` suite → 9 passed, including `testRoundTripFuzzPow` (5096 runs).
- Full `forge test` → 452 passed; the only 5 failures are the pre-existing `testProdDeployment*` fork tests that require live RPC env vars (`ARBITRUM_RPC_URL` etc.) not set in the local sandbox — unrelated to this change (which is test-only and touches no source).

Fixes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)
