### PR TITLE
fix(test): correct testEqXEqY exponent assertion for negative coefficients

### DIFF
--- a/test/src/lib/implementation/LibDecimalFloatImplementation.eq.t.sol
+++ b/test/src/lib/implementation/LibDecimalFloatImplementation.eq.t.sol
@@ -27,34 +27,59 @@ contract LibDecimalFloatImplementationEqTest is Test {
         LibDecimalFloatImplementation.eq(1, type(int256).max, 1, type(int256).min);
     }
 
-    /// if xeX == yeY, then x / y == 10^(X - Y) || y / x == 10^(Y - X)
-    function testEqXEqY(int256 x, int256 exponentX, int256 y, int256 exponentY) external pure {
+    /// if xeX == yeY with x != y, both coefficients are nonzero with the same
+    /// sign and the side with the SMALLER exponent carries the scaled-up
+    /// coefficient: exponentX > exponentY implies y == x * 10^(X - Y), and
+    /// exponentY > exponentX implies x == y * 10^(Y - X). This holds for
+    /// negative coefficients too because the exact-multiple relation is
+    /// signed; only exponent order (never signed coefficient order) selects
+    /// which side is scaled up.
+    function checkEqXEqY(int256 x, int256 exponentX, int256 y, int256 exponentY) internal pure {
         bool eq = LibDecimalFloatImplementation.eq(x, exponentX, y, exponentY);
 
         if (eq) {
             if (x == y) {
                 assertTrue(exponentX == exponentY || x == 0);
-            } else if (y > x) {
-                assertTrue(exponentY < exponentX, "y > x but exponentY >= exponentX");
-                assertTrue(exponentX - exponentY < 77, "y > x but exponentX - exponentY >= 77");
-                // we assert that exponentY < exponentX and the diff is < 77.
+            } else if (exponentX > exponentY) {
+                assertTrue(exponentX - exponentY < 77, "exponentX > exponentY but exponentX - exponentY >= 77");
+                // The exponent diff is in [1, 76] so the power fits int256 and
+                // the cast is safe.
                 // forge-lint: disable-next-line(unsafe-typecast)
-                assertEq(x / y, int256(10 ** uint256(exponentX - exponentY)), "y > x but x / y != 10^(X - Y)");
-                assertEq(x % y, 0, "y > x but x % y != 0");
+                assertEq(
+                    y / x, int256(10 ** uint256(exponentX - exponentY)), "exponentX > exponentY but y / x != 10^(X - Y)"
+                );
+                assertEq(y % x, 0, "exponentX > exponentY but y % x != 0");
             } else {
-                assertTrue(exponentX < exponentY, "x < y but exponentX >= exponentY");
-                assertTrue(exponentY - exponentX < 77, "x < y but exponentY - exponentX >= 77");
-                // x < y and they are eq so exponentY - exponentX will always be
-                // positive.
+                assertTrue(exponentY > exponentX, "x != y but exponentX == exponentY");
+                assertTrue(exponentY - exponentX < 77, "exponentY > exponentX but exponentY - exponentX >= 77");
+                // The exponent diff is in [1, 76] so the power fits int256 and
+                // the cast is safe.
                 // forge-lint: disable-next-line(unsafe-typecast)
-                assertEq(y / x, int256(10 ** uint256(exponentY - exponentX)), "x < y but y / x != 10^(Y - X)");
-                assertEq(y % x, 0, "x < y but y % x != 0");
+                assertEq(
+                    x / y, int256(10 ** uint256(exponentY - exponentX)), "exponentY > exponentX but x / y != 10^(Y - X)"
+                );
+                assertEq(x % y, 0, "exponentY > exponentX but x % y != 0");
             }
         } else {
             if (x == y) {
                 assertTrue(exponentX != exponentY);
             }
         }
+    }
+
+    /// if xeX == yeY, the coefficient at the smaller exponent is the other
+    /// coefficient scaled up by 10^(exponent diff).
+    function testEqXEqY(int256 x, int256 exponentX, int256 y, int256 exponentY) external pure {
+        checkEqXEqY(x, exponentX, y, exponentY);
+    }
+
+    /// A concrete equal-value pair with negative coefficients and distinct
+    /// representations: -1000e-10 == -10000000000e-17. Signed coefficient
+    /// order inverts relative to magnitude for negatives, so this pins the
+    /// exponent-order branching of the property above.
+    function testEqXEqYNegativeCoefficients() external pure {
+        assertTrue(LibDecimalFloatImplementation.eq(-1000, -10, -10000000000, -17), "equal negative pair must be eq");
+        checkEqXEqY(-1000, -10, -10000000000, -17);
     }
 
     /// xeX != yeY if x != y (assuming maximized representation)


### PR DESCRIPTION
## What was wrong

`testEqXEqY` selects its assertion branch by SIGNED coefficient order (`y > x`), but signed order coincides with magnitude order only for positive coefficients — it inverts for negative ones. For an equal-value pair like `-1000e-10 == -10000000000e-17`, the scaled-up coefficient (`-10000000000`) is signed-*less* than the other side, so the pair lands in the branch whose exponent-ordering assertion (`exponentX < exponentY`) is backwards for it and the test reverts. This is the fuzz flake currently redding sibling PRs (counterexample `args=[-1000, -10, -10000000000, -17]`).

The division assertions were additionally inverted relative to the scale relation for ALL signs: for equal values `x·10^X == y·10^Y` with `x != y`, the smaller-exponent side carries the scaled-up coefficient (`exponentX > exponentY ⟹ y == x·10^(X - Y)`), so the exact quotient is `y / x` — the old branch asserted `x / y`, which truncates to 0. The property body was effectively unsatisfiable whenever the fuzzer constructed a genuine equal-value distinct-representation pair; random `int256` quadruples essentially never hit one until now.

The fix branches on exponent order (sign-agnostic), asserts the exact-multiple relation in the correct direction, and pins the found counterexample as a concrete regression test (`testEqXEqYNegativeCoefficients`, which also asserts the pair IS eq). No weakening: the property still requires the exact power-of-ten quotient, zero remainder, and the < 77 exponent-diff bound.

## QA
- Discriminating tests: `testEqXEqYNegativeCoefficients` (concrete regression, `-1000e-10 == -10000000000e-17`) + `testEqXEqY` (fuzz, 100000 runs, seed `0xdeadbeef`) — old assertions fail the counterexample, fixed assertions pass it, and both tests kill mutants of `eq` and of the assertion operands (below)
- Mutations applied:
  - test/src/lib/implementation/LibDecimalFloatImplementation.eq.t.sol:43 → branch selection reverted to the old signed order `else if (y > x)` (+ `assertTrue(exponentY < exponentX)`) → killed by `testEqXEqYNegativeCoefficients` (counterexample routes to the wrong branch, exponent-order assertion trips); restored → PASS
  - src/lib/implementation/LibDecimalFloatImplementation.sol:740 → `eq` return `signedCoefficientA == signedCoefficientB` → `!=` → killed by `testEqXEqYNegativeCoefficients` (`equal negative pair must be eq`) AND by `testEqXEqY` fuzz (immediate counterexample at seed `0xdeadbeef`: unequal pair reported eq, ratio assertions trip); restored → PASS
  - test/src/lib/implementation/LibDecimalFloatImplementation.eq.t.sol:49 → assertion operand `y / x` → `x / y` in the `exponentX > exponentY` branch → killed by `testEqXEqYNegativeCoefficients` (`0 != 10000000`); restored → PASS
- Oracle: `eq` semantics derived independently from `compareRescale` (rescales the higher-exponent side's coefficient up by `10^diff`, guard makes diff > 76 unequal): equal values with `x != y` are nonzero, same-signed, and the smaller-exponent side is the exact signed multiple `10^(exponent diff)` of the other, so the quotient is exact and positive for both signs
- Category check: the property must hold for the whole category of equal-value distinct-representation pairs regardless of coefficient sign; the fixed branch keys on exponent order (sign-agnostic), verified across signs by the fuzz property at 100000 runs / fixed seed plus the pinned negative regression; full eq suite 17/17 PASS

Refs #253 — this pre-existing main flake reds sibling PRs' `rainix-sol/test` runs whenever the fuzzer finds an equal-value pair.

Co-Authored-By: Claude <noreply@anthropic.com>
